### PR TITLE
Faded Ghost Items for the Item Pool + Lowered Opacity

### DIFF
--- a/KhTracker/MainWindow.xaml
+++ b/KhTracker/MainWindow.xaml
@@ -1108,64 +1108,64 @@
 
 
                 <!-- Ghost Row 1 -->
-                <local:Item x:Name="Ghost_Report1" Content="{DynamicResource Min-AnsemReport01}" Grid.Row="4" Grid.Column="0" Panel.ZIndex="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Report2" Content="{DynamicResource Min-AnsemReport02}" Grid.Row="4" Grid.Column="1" Panel.ZIndex="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Report3" Content="{DynamicResource Min-AnsemReport03}" Grid.Row="4" Grid.Column="2" Panel.ZIndex="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Report4" Content="{DynamicResource Min-AnsemReport04}" Grid.Row="4" Grid.Column="3" Panel.ZIndex="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Report5" Content="{DynamicResource Min-AnsemReport05}" Grid.Row="4" Grid.Column="4" Panel.ZIndex="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Report6" Content="{DynamicResource Min-AnsemReport06}" Grid.Row="4" Grid.Column="5" Panel.ZIndex="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Report7" Content="{DynamicResource Min-AnsemReport07}" Grid.Row="4" Grid.Column="6" Panel.ZIndex="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Report8" Content="{DynamicResource Min-AnsemReport08}" Grid.Row="4" Grid.Column="7" Panel.ZIndex="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Report9" Content="{DynamicResource Min-AnsemReport09}" Grid.Row="4" Grid.Column="8" Panel.ZIndex="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Report10" Content="{DynamicResource Min-AnsemReport10}" Grid.Row="4" Grid.Column="9" Panel.ZIndex="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Report11" Content="{DynamicResource Min-AnsemReport11}" Grid.Row="4" Grid.Column="10" Panel.ZIndex="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Report12" Content="{DynamicResource Min-AnsemReport12}" Grid.Row="4" Grid.Column="11" Panel.ZIndex="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Report13" Content="{DynamicResource Min-AnsemReport13}" Grid.Row="4" Grid.Column="12" Panel.ZIndex="0" Opacity="0.6"/>
+                <local:Item x:Name="Ghost_Report1" Content="{DynamicResource Min-AnsemReport01}" Grid.Row="4" Grid.Column="0" Panel.ZIndex="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Report2" Content="{DynamicResource Min-AnsemReport02}" Grid.Row="4" Grid.Column="1" Panel.ZIndex="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Report3" Content="{DynamicResource Min-AnsemReport03}" Grid.Row="4" Grid.Column="2" Panel.ZIndex="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Report4" Content="{DynamicResource Min-AnsemReport04}" Grid.Row="4" Grid.Column="3" Panel.ZIndex="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Report5" Content="{DynamicResource Min-AnsemReport05}" Grid.Row="4" Grid.Column="4" Panel.ZIndex="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Report6" Content="{DynamicResource Min-AnsemReport06}" Grid.Row="4" Grid.Column="5" Panel.ZIndex="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Report7" Content="{DynamicResource Min-AnsemReport07}" Grid.Row="4" Grid.Column="6" Panel.ZIndex="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Report8" Content="{DynamicResource Min-AnsemReport08}" Grid.Row="4" Grid.Column="7" Panel.ZIndex="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Report9" Content="{DynamicResource Min-AnsemReport09}" Grid.Row="4" Grid.Column="8" Panel.ZIndex="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Report10" Content="{DynamicResource Min-AnsemReport10}" Grid.Row="4" Grid.Column="9" Panel.ZIndex="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Report11" Content="{DynamicResource Min-AnsemReport11}" Grid.Row="4" Grid.Column="10" Panel.ZIndex="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Report12" Content="{DynamicResource Min-AnsemReport12}" Grid.Row="4" Grid.Column="11" Panel.ZIndex="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Report13" Content="{DynamicResource Min-AnsemReport13}" Grid.Row="4" Grid.Column="12" Panel.ZIndex="0" Opacity="0.5"/>
 
                 <!-- Ghost Row 2 -->
-                <local:Item x:Name="Ghost_Fire1" Content="{DynamicResource Min-Fire}" Grid.Row="5" Grid.Column="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Fire2" Content="{DynamicResource Min-Fire}" Grid.Row="5" Grid.Column="1" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Fire3" Content="{DynamicResource Min-Fire}" Grid.Row="5" Grid.Column="2" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Blizzard1" Content="{DynamicResource Min-Blizzard}" Grid.Row="5" Grid.Column="3" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Blizzard2" Content="{DynamicResource Min-Blizzard}" Grid.Row="5" Grid.Column="4" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Blizzard3" Content="{DynamicResource Min-Blizzard}" Grid.Row="5" Grid.Column="5" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Thunder1" Content="{DynamicResource Min-Thunder}" Grid.Row="5" Grid.Column="6" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Thunder2" Content="{DynamicResource Min-Thunder}" Grid.Row="5" Grid.Column="7" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Thunder3" Content="{DynamicResource Min-Thunder}" Grid.Row="5" Grid.Column="8" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Cure1" Content="{DynamicResource Min-Cure}" Grid.Row="5" Grid.Column="9" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Cure2" Content="{DynamicResource Min-Cure}" Grid.Row="5" Grid.Column="10" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Cure3" Content="{DynamicResource Min-Cure}" Grid.Row="5" Grid.Column="11" Opacity="0.6"/>
+                <local:Item x:Name="Ghost_Fire1" Content="{DynamicResource Min-Fire}" Grid.Row="5" Grid.Column="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Fire2" Content="{DynamicResource Min-Fire}" Grid.Row="5" Grid.Column="1" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Fire3" Content="{DynamicResource Min-Fire}" Grid.Row="5" Grid.Column="2" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Blizzard1" Content="{DynamicResource Min-Blizzard}" Grid.Row="5" Grid.Column="3" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Blizzard2" Content="{DynamicResource Min-Blizzard}" Grid.Row="5" Grid.Column="4" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Blizzard3" Content="{DynamicResource Min-Blizzard}" Grid.Row="5" Grid.Column="5" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Thunder1" Content="{DynamicResource Min-Thunder}" Grid.Row="5" Grid.Column="6" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Thunder2" Content="{DynamicResource Min-Thunder}" Grid.Row="5" Grid.Column="7" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Thunder3" Content="{DynamicResource Min-Thunder}" Grid.Row="5" Grid.Column="8" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Cure1" Content="{DynamicResource Min-Cure}" Grid.Row="5" Grid.Column="9" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Cure2" Content="{DynamicResource Min-Cure}" Grid.Row="5" Grid.Column="10" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Cure3" Content="{DynamicResource Min-Cure}" Grid.Row="5" Grid.Column="11" Opacity="0.5"/>
                 <!--local:Item x:Name="Ghost_HadesCup" Content="{DynamicResource Min-HadesCup}" Grid.Row="5" Grid.Column="12" Opacity="0.5"/-->
 
                 <!-- Ghost Row 3 -->
-                <local:Item x:Name="Ghost_Reflect1" Content="{DynamicResource Min-Reflect}" Grid.Row="6" Grid.Column="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Reflect2" Content="{DynamicResource Min-Reflect}" Grid.Row="6" Grid.Column="1" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Reflect3" Content="{DynamicResource Min-Reflect}" Grid.Row="6" Grid.Column="2" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Magnet1" Content="{DynamicResource Min-Magnet}" Grid.Row="6" Grid.Column="3" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Magnet2" Content="{DynamicResource Min-Magnet}" Grid.Row="6" Grid.Column="4" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Magnet3" Content="{DynamicResource Min-Magnet}" Grid.Row="6" Grid.Column="5" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Valor" Content="{DynamicResource Min-Valor}" Grid.Row="6" Grid.Column="6" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Wisdom" Content="{DynamicResource Min-Wisdom}" Grid.Row="6" Grid.Column="7" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Limit" Content="{DynamicResource Min-Limit}" Grid.Row="6" Grid.Column="8" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Master" Content="{DynamicResource Min-Master}" Grid.Row="6" Grid.Column="9" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Final" Content="{DynamicResource Min-Final}" Grid.Row="6" Grid.Column="10" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_OnceMore" Content="{DynamicResource Min-OnceMore}" Grid.Row="6" Grid.Column="11" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_SecondChance" Content="{DynamicResource Min-SecondChance}" Grid.Row="6" Grid.Column="12" Opacity="0.6"/>
+                <local:Item x:Name="Ghost_Reflect1" Content="{DynamicResource Min-Reflect}" Grid.Row="6" Grid.Column="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Reflect2" Content="{DynamicResource Min-Reflect}" Grid.Row="6" Grid.Column="1" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Reflect3" Content="{DynamicResource Min-Reflect}" Grid.Row="6" Grid.Column="2" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Magnet1" Content="{DynamicResource Min-Magnet}" Grid.Row="6" Grid.Column="3" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Magnet2" Content="{DynamicResource Min-Magnet}" Grid.Row="6" Grid.Column="4" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Magnet3" Content="{DynamicResource Min-Magnet}" Grid.Row="6" Grid.Column="5" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Valor" Content="{DynamicResource Min-Valor}" Grid.Row="6" Grid.Column="6" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Wisdom" Content="{DynamicResource Min-Wisdom}" Grid.Row="6" Grid.Column="7" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Limit" Content="{DynamicResource Min-Limit}" Grid.Row="6" Grid.Column="8" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Master" Content="{DynamicResource Min-Master}" Grid.Row="6" Grid.Column="9" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Final" Content="{DynamicResource Min-Final}" Grid.Row="6" Grid.Column="10" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_OnceMore" Content="{DynamicResource Min-OnceMore}" Grid.Row="6" Grid.Column="11" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_SecondChance" Content="{DynamicResource Min-SecondChance}" Grid.Row="6" Grid.Column="12" Opacity="0.5"/>
 
                 <!-- Ghost Row 4 -->
-                <local:Item x:Name="Ghost_TornPage1" Content="{DynamicResource Min-TornPage}" Grid.Row="7" Grid.Column="0" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_TornPage2" Content="{DynamicResource Min-TornPage}" Grid.Row="7" Grid.Column="1" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_TornPage3" Content="{DynamicResource Min-TornPage}" Grid.Row="7" Grid.Column="2" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_TornPage4" Content="{DynamicResource Min-TornPage}" Grid.Row="7" Grid.Column="3" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_TornPage5" Content="{DynamicResource Min-TornPage}" Grid.Row="7" Grid.Column="4" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Baseball" Content="{DynamicResource Min-ChickenLittle}" Grid.Row="7" Grid.Column="5" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Lamp" Content="{DynamicResource Min-Genie}" Grid.Row="7" Grid.Column="6" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Ukulele" Content="{DynamicResource Min-Stitch}" Grid.Row="7" Grid.Column="7" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Feather" Content="{DynamicResource Min-PeterPan}" Grid.Row="7" Grid.Column="8" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Connection" Content="{DynamicResource Min-ProofOfCon}" Grid.Row="7" Grid.Column="9" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Nonexistence" Content="{DynamicResource Min-ProofOfNon}" Grid.Row="7" Grid.Column="10" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_Peace" Content="{DynamicResource Min-ProofOfPea}" Grid.Row="7" Grid.Column="11" Opacity="0.6"/>
-                <local:Item x:Name="Ghost_PromiseCharm" Content="{DynamicResource Min-PromiseCharm}" Grid.Row="7" Grid.Column="12" Opacity="0.6"/>
+                <local:Item x:Name="Ghost_TornPage1" Content="{DynamicResource Min-TornPage}" Grid.Row="7" Grid.Column="0" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_TornPage2" Content="{DynamicResource Min-TornPage}" Grid.Row="7" Grid.Column="1" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_TornPage3" Content="{DynamicResource Min-TornPage}" Grid.Row="7" Grid.Column="2" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_TornPage4" Content="{DynamicResource Min-TornPage}" Grid.Row="7" Grid.Column="3" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_TornPage5" Content="{DynamicResource Min-TornPage}" Grid.Row="7" Grid.Column="4" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Baseball" Content="{DynamicResource Min-ChickenLittle}" Grid.Row="7" Grid.Column="5" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Lamp" Content="{DynamicResource Min-Genie}" Grid.Row="7" Grid.Column="6" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Ukulele" Content="{DynamicResource Min-Stitch}" Grid.Row="7" Grid.Column="7" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Feather" Content="{DynamicResource Min-PeterPan}" Grid.Row="7" Grid.Column="8" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Connection" Content="{DynamicResource Min-ProofOfCon}" Grid.Row="7" Grid.Column="9" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Nonexistence" Content="{DynamicResource Min-ProofOfNon}" Grid.Row="7" Grid.Column="10" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_Peace" Content="{DynamicResource Min-ProofOfPea}" Grid.Row="7" Grid.Column="11" Opacity="0.5"/>
+                <local:Item x:Name="Ghost_PromiseCharm" Content="{DynamicResource Min-PromiseCharm}" Grid.Row="7" Grid.Column="12" Opacity="0.5"/>
             </Grid>
 
         </Grid>

--- a/KhTracker/WorldGrid.xaml.cs
+++ b/KhTracker/WorldGrid.xaml.cs
@@ -29,6 +29,9 @@ namespace KhTracker
         public static int Ghost_Magnet = 0;
         public static int Ghost_Pages = 0;
 
+        //A single spot to have referenced for the opacity of the ghost checks idk where to put this
+        public static double universalOpacity = 0.5;
+
         public WorldGrid()
         {
             InitializeComponent();
@@ -183,6 +186,9 @@ namespace KhTracker
             window.ItemPool.Children.Remove(item);
             Handle_WorldGrid(item, true);
 
+            //Reset any obtained item to be normal transparency
+            item.Opacity = 1.0;
+
             // update collection count
             window.IncrementCollected();
 
@@ -201,6 +207,8 @@ namespace KhTracker
             item.MouseDown += item.Item_Return;
 
             item.DragDropEventFire(item.Name, Name.Remove(Name.Length - 4, 4), true);
+
+            SetItemPoolGhosts(window);
         }
 
         public bool Handle_Report(Item item, MainWindow window, Data data)
@@ -548,6 +556,96 @@ namespace KhTracker
             else
             {
                 Data.WorldItems[world].Add(GhostName);
+            }
+
+            //don't bother messing with magic or pages
+            if (!itemname.Contains("Fire") && !itemname.Contains("Blizzard") && !itemname.Contains("Thunder")
+                && !itemname.Contains("Cure") && !itemname.Contains("Reflect") && !itemname.Contains("Magnet")
+                && !itemname.Contains("Page"))
+                window.ItemPool.Children[window.ItemPool.Children.IndexOf((Item)window.ItemPool.FindName(convertItemNames[itemname]))].Opacity = universalOpacity;
+        }
+
+        public void SetItemPoolGhosts(MainWindow window)
+        {
+            string checkName = "";
+            //Magic
+            //fires
+            for (int i = 0, j = 0; i < 3 && j < Ghost_Fire; i++)
+            {
+                checkName = "Fire" + (i + 1).ToString();
+                //if the item is not in the bottom item pool, skip changing it's opacity
+                if (window.ItemPool.Children.Contains((Item)window.ItemPool.FindName(checkName)))
+                {
+                    j++;
+                    window.ItemPool.Children[window.ItemPool.Children.IndexOf((Item)window.ItemPool.FindName(checkName))].Opacity = universalOpacity;
+                }
+            }
+            //blizzards
+            for (int i = 0, j = 0; i < 3 && j < Ghost_Blizzard; i++)
+            {
+                checkName = "Blizzard" + (i + 1).ToString();
+                //if the item is not in the bottom item pool, skip changing it's opacity
+                if (window.ItemPool.Children.Contains((Item)window.ItemPool.FindName(checkName)))
+                {
+                    j++;
+                    window.ItemPool.Children[window.ItemPool.Children.IndexOf((Item)window.ItemPool.FindName(checkName))].Opacity = universalOpacity;
+                }
+            }
+            //thunders
+            for (int i = 0, j = 0; i < 3 && j < Ghost_Thunder; i++)
+            {
+                checkName = "Thunder" + (i + 1).ToString();
+                //if the item is not in the bottom item pool, skip changing it's opacity
+                if (window.ItemPool.Children.Contains((Item)window.ItemPool.FindName(checkName)))
+                {
+                    j++;
+                    window.ItemPool.Children[window.ItemPool.Children.IndexOf((Item)window.ItemPool.FindName(checkName))].Opacity = universalOpacity;
+                }
+            }
+            //cures
+            for (int i = 0, j = 0; i < 3 && j < Ghost_Cure; i++)
+            {
+                checkName = "Cure" + (i + 1).ToString();
+                //if the item is not in the bottom item pool, skip changing it's opacity
+                if (window.ItemPool.Children.Contains((Item)window.ItemPool.FindName(checkName)))
+                {
+                    j++;
+                    window.ItemPool.Children[window.ItemPool.Children.IndexOf((Item)window.ItemPool.FindName(checkName))].Opacity = universalOpacity;
+                }
+            }
+            //reflects
+            for (int i = 0, j = 0; i < 3 && j < Ghost_Reflect; i++)
+            {
+                checkName = "Reflect" + (i + 1).ToString();
+                //if the item is not in the bottom item pool, skip changing it's opacity
+                if (window.ItemPool.Children.Contains((Item)window.ItemPool.FindName(checkName)))
+                {
+                    j++;
+                    window.ItemPool.Children[window.ItemPool.Children.IndexOf((Item)window.ItemPool.FindName(checkName))].Opacity = universalOpacity;
+                }
+            }
+            //magnets
+            for (int i = 0, j = 0; i < 3 && j < Ghost_Magnet; i++)
+            {
+                checkName = "Magnet" + (i + 1).ToString();
+                //if the item is not in the bottom item pool, skip changing it's opacity
+                if (window.ItemPool.Children.Contains((Item)window.ItemPool.FindName(checkName)))
+                {
+                    j++;
+                    window.ItemPool.Children[window.ItemPool.Children.IndexOf((Item)window.ItemPool.FindName(checkName))].Opacity = universalOpacity;
+                }
+            }
+
+            //Pages
+            for (int i = 0, j = 0; i < 5 && j < Ghost_Pages; i++)
+            {
+                checkName = "TornPage" + (i + 1).ToString();
+                //if the item is not in the bottom item pool, skip changing it's opacity
+                if (window.ItemPool.Children.Contains((Item)window.ItemPool.FindName(checkName)))
+                {
+                    j++;
+                    window.ItemPool.Children[window.ItemPool.Children.IndexOf((Item)window.ItemPool.FindName(checkName))].Opacity = universalOpacity;
+                }
             }
         }
 


### PR DESCRIPTION
Left-most magics and pages will be faded out when hinted as Ghost Hints
Lowered opacity from 0.6 to 0.5 + let a single variable adjust it within WorldGrid.xaml.cs ONLY (for now can ignore)