### PR TITLE
Added logic for hinting worlds that are empty last

### DIFF
--- a/KhTracker/AutoTracking/AutoTracker.cs
+++ b/KhTracker/AutoTracking/AutoTracker.cs
@@ -1105,7 +1105,7 @@ namespace KhTracker
                             if ((world.eventID1 == 151) && world.eventComplete == 1) // AS Zexion finish
                                 UpdateProgressionPoints(world.worldName,  curProg = 9);
                             else if ((world.eventID1 == 152) && world.eventComplete == 1) // Data Zexion finish
-                                UpdateProgressionPoints(world.worldName, 9);
+                                UpdateProgressionPoints(world.worldName, 10);
                             break;
                         default:
                             return;
@@ -1147,7 +1147,7 @@ namespace KhTracker
                             if ((world.eventID1 == 142) && world.eventComplete == 1) // AS Lexaeus finish
                                 UpdateProgressionPoints(world.worldName,  curProg = 8);
                             else if ((world.eventID1 == 147) && world.eventComplete == 1) // Data Lexaeus
-                                UpdateProgressionPoints(world.worldName,  8);
+                                UpdateProgressionPoints(world.worldName,  9);
                             break;
                         default:
                             return;
@@ -1310,7 +1310,7 @@ namespace KhTracker
                                 if (world.eventID1 == 145)
                                     UpdateProgressionPoints(world.worldName, 7); // AS
                                 else
-                                    UpdateProgressionPoints(world.worldName, 7); // Data
+                                    UpdateProgressionPoints(world.worldName, 8); // Data
                             }
                             break;
                         case 7:
@@ -1320,7 +1320,7 @@ namespace KhTracker
                                     curProg = 9; //marluxia + LW finished
                                 else if (curProg != 9)
                                     curProg = 8;
-                                UpdateProgressionPoints(world.worldName,  8);
+                                UpdateProgressionPoints(world.worldName,  9);
                             }
                             break;
                         default:
@@ -1361,7 +1361,7 @@ namespace KhTracker
                             if ((world.eventID1 == 115) && world.eventComplete == 1) // AS Vexen finish
                                 UpdateProgressionPoints(world.worldName,  curProg = 8);
                             else if ((world.eventID1 == 146) && world.eventComplete == 1) // Data Vexen finish
-                                UpdateProgressionPoints(world.worldName, 8);
+                                UpdateProgressionPoints(world.worldName, 9);
                             break;
                         default:
                             return;
@@ -1439,7 +1439,7 @@ namespace KhTracker
                             if ((world.eventID1 == 143) && world.eventComplete == 1) // AS Larxene finish
                                 UpdateProgressionPoints(world.worldName,  curProg = 6);
                             else if ((world.eventID1 == 148) && world.eventComplete == 1) // Data Larxene finish
-                                UpdateProgressionPoints(world.worldName,  6);
+                                UpdateProgressionPoints(world.worldName,  7);
                             break;
                         default:
                             return;

--- a/KhTracker/AutoTracking/AutoTracker.cs
+++ b/KhTracker/AutoTracking/AutoTracker.cs
@@ -1201,23 +1201,23 @@ namespace KhTracker
                                 UpdateProgressionPoints(world.worldName,  curProg = 1);
                             break;
                         case 4:
-                            if (world.eventID3 == 1) // Piglet's house
+                            if (world.eventID3 == 4) // Piglet's house
                                 UpdateProgressionPoints(world.worldName,  curProg = 2);
                             break;
                         case 3:
-                            if (world.eventID3 == 1) // Rabbit's house
+                            if (world.eventID3 == 4) // Rabbit's house
                                 UpdateProgressionPoints(world.worldName,  curProg = 3);
                             break;
                         case 5:
-                            if (world.eventID3 == 1) // Kanga's house
+                            if (world.eventID3 == 4) // Kanga's house
                                 UpdateProgressionPoints(world.worldName,  curProg = 4);
                             break;
                         case 9:
-                            if (world.eventID3 == 1) // Spooky Cave
+                            if (world.eventID3 == 3D) // Spooky Cave
                                 UpdateProgressionPoints(world.worldName,  curProg = 5);
                             break;
                         case 1:
-                            if (world.eventID3 == 1) // Starry Hill
+                            if (world.eventID3 == 34) // Starry Hill
                                 UpdateProgressionPoints(world.worldName,  curProg = 6);
                             break;
                         default:

--- a/KhTracker/AutoTracking/AutoTracker.cs
+++ b/KhTracker/AutoTracking/AutoTracker.cs
@@ -1506,7 +1506,9 @@ namespace KhTracker
                             break;
                         case 20:
                             if (world.eventID1 == 98 && world.eventComplete == 1) // Data Xemnas finish
-                                UpdateProgressionPoints(world.worldName,  curProg = 7);
+                                UpdateProgressionPoints(world.worldName, curProg = 7);
+                            else if (world.eventID1 == 74 && world.eventComplete == 1 && data.revealFinalXemnas) // Regular Final Xemnas finish
+                                UpdateProgressionPointsTWTNW(world.worldName);
                             break;
                         default:
                             return;
@@ -2281,6 +2283,22 @@ namespace KhTracker
                 return;
 
             AddProgressionPoints(GetProgressionPointsReward(worldName, prog));
+            data.PrevEventID1 = world.eventID1;
+            data.PrevEventID3 = world.eventID3;
+            data.PrevWorld = world.worldName;
+            data.PrevRoomNum = world.roomNumber;
+        }
+        public void UpdateProgressionPointsTWTNW(string worldName)
+        {
+            //if event is current, skip
+            if ((world.eventID1 == data.PrevEventID1 && world.eventID3 == data.PrevEventID3
+                && world.worldName == data.PrevWorld && world.roomNumber == data.PrevRoomNum)
+                || !data.UsingProgressionHints)
+                return;
+            Console.WriteLine("Defeated Final Xemnas");
+            data.TWTNW_ProgressionValues.Add(200);
+            AddProgressionPoints(GetProgressionPointsReward(worldName, data.TWTNW_ProgressionValues.Count));
+            data.TotalProgressionPoints -= 200;
             data.PrevEventID1 = world.eventID1;
             data.PrevEventID3 = world.eventID3;
             data.PrevWorld = world.worldName;

--- a/KhTracker/AutoTracking/AutoTracker.cs
+++ b/KhTracker/AutoTracking/AutoTracker.cs
@@ -984,6 +984,7 @@ namespace KhTracker
                                 curKey = data.ProgressKeys["GoA"][1];
                                 GoAProgression.SetResourceReference(ContentProperty, Prog + curKey);
                                 data.WorldsData["GoA"].progress = 1;
+                                UpdateProgressionPoints("CavernofRemembrance", 0);
                                 return;
                             }
                             break;
@@ -993,6 +994,7 @@ namespace KhTracker
                                 curKey = data.ProgressKeys["GoA"][5];
                                 GoAProgression.SetResourceReference(ContentProperty, Prog + curKey);
                                 data.WorldsData["GoA"].progress = 5;
+                                UpdateProgressionPoints("CavernofRemembrance", 1);
                                 return;
                             }
                             break;
@@ -1002,6 +1004,7 @@ namespace KhTracker
                                 curKey = data.ProgressKeys["GoA"][2];
                                 GoAProgression.SetResourceReference(ContentProperty, Prog + curKey);
                                 data.WorldsData["GoA"].progress = 2;
+                                UpdateProgressionPoints("CavernofRemembrance", 2);
                                 return;
                             }
                             if (world.eventID3 == 2 && world.eventComplete == 1) //second fight
@@ -1009,6 +1012,7 @@ namespace KhTracker
                                 curKey = data.ProgressKeys["GoA"][3];
                                 GoAProgression.SetResourceReference(ContentProperty, Prog + curKey);
                                 data.WorldsData["GoA"].progress = 3;
+                                UpdateProgressionPoints("CavernofRemembrance", 3);
                                 return;
                             }
                             break;
@@ -1018,6 +1022,7 @@ namespace KhTracker
                                 curKey = data.ProgressKeys["GoA"][4];
                                 GoAProgression.SetResourceReference(ContentProperty, Prog + curKey);
                                 data.WorldsData["GoA"].progress = 4;
+                                UpdateProgressionPoints("CavernofRemembrance", 4);
                                 return;
                             }
                             break;

--- a/KhTracker/AutoTracking/AutoTracker.cs
+++ b/KhTracker/AutoTracking/AutoTracker.cs
@@ -994,7 +994,7 @@ namespace KhTracker
                                 curKey = data.ProgressKeys["GoA"][5];
                                 GoAProgression.SetResourceReference(ContentProperty, Prog + curKey);
                                 data.WorldsData["GoA"].progress = 5;
-                                UpdateProgressionPoints("CavernofRemembrance", 1);
+                                UpdateProgressionPoints("CavernofRemembrance", 2);
                                 return;
                             }
                             break;
@@ -1004,7 +1004,7 @@ namespace KhTracker
                                 curKey = data.ProgressKeys["GoA"][2];
                                 GoAProgression.SetResourceReference(ContentProperty, Prog + curKey);
                                 data.WorldsData["GoA"].progress = 2;
-                                UpdateProgressionPoints("CavernofRemembrance", 2);
+                                UpdateProgressionPoints("CavernofRemembrance", 1);
                                 return;
                             }
                             if (world.eventID3 == 2 && world.eventComplete == 1) //second fight

--- a/KhTracker/AutoTracking/AutoTracker.cs
+++ b/KhTracker/AutoTracking/AutoTracker.cs
@@ -984,7 +984,7 @@ namespace KhTracker
                                 curKey = data.ProgressKeys["GoA"][1];
                                 GoAProgression.SetResourceReference(ContentProperty, Prog + curKey);
                                 data.WorldsData["GoA"].progress = 1;
-                                UpdateProgressionPoints("CavernofRemembrance", 0);
+                                UpdateProgressionPoints("CavernofRemembrance", 1);
                                 return;
                             }
                             break;
@@ -994,7 +994,7 @@ namespace KhTracker
                                 curKey = data.ProgressKeys["GoA"][5];
                                 GoAProgression.SetResourceReference(ContentProperty, Prog + curKey);
                                 data.WorldsData["GoA"].progress = 5;
-                                UpdateProgressionPoints("CavernofRemembrance", 2);
+                                UpdateProgressionPoints("CavernofRemembrance", 3);
                                 return;
                             }
                             break;
@@ -1004,7 +1004,7 @@ namespace KhTracker
                                 curKey = data.ProgressKeys["GoA"][2];
                                 GoAProgression.SetResourceReference(ContentProperty, Prog + curKey);
                                 data.WorldsData["GoA"].progress = 2;
-                                UpdateProgressionPoints("CavernofRemembrance", 1);
+                                UpdateProgressionPoints("CavernofRemembrance", 2);
                                 return;
                             }
                             if (world.eventID3 == 2 && world.eventComplete == 1) //second fight
@@ -1012,7 +1012,7 @@ namespace KhTracker
                                 curKey = data.ProgressKeys["GoA"][3];
                                 GoAProgression.SetResourceReference(ContentProperty, Prog + curKey);
                                 data.WorldsData["GoA"].progress = 3;
-                                UpdateProgressionPoints("CavernofRemembrance", 3);
+                                UpdateProgressionPoints("CavernofRemembrance", 4);
                                 return;
                             }
                             break;
@@ -1022,7 +1022,7 @@ namespace KhTracker
                                 curKey = data.ProgressKeys["GoA"][4];
                                 GoAProgression.SetResourceReference(ContentProperty, Prog + curKey);
                                 data.WorldsData["GoA"].progress = 4;
-                                UpdateProgressionPoints("CavernofRemembrance", 4);
+                                UpdateProgressionPoints("CavernofRemembrance", 5);
                                 return;
                             }
                             break;

--- a/KhTracker/Core/Data.cs
+++ b/KhTracker/Core/Data.cs
@@ -92,6 +92,7 @@ namespace KhTracker
         public int TotalProgressionPoints = 0;
         public int WorldsEnabled = 0;
         public int ProgressionHash = 0;
+        public bool revealFinalXemnas = false;
 
         #region Progression Tracking
         public int PrevEventID1 = 0;

--- a/KhTracker/Core/Data.cs
+++ b/KhTracker/Core/Data.cs
@@ -146,6 +146,7 @@ namespace KhTracker
         public List<int> STT_ProgressionValues = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 };
         public List<int> TT_ProgressionValues = new List<int>() { 1, 2, 3, 4, 5, 6, 7 };
         public List<int> HB_ProgressionValues = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+        public List<int> CoR_ProgressionValues = new List<int>() { 0, 0, 0, 0, 0 };
         public List<int> BC_ProgressionValues = new List<int>() { 1, 2, 3, 4, 5, 6, 7 };
         public List<int> OC_ProgressionValues = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
         public List<int> AG_ProgressionValues = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 };

--- a/KhTracker/Core/HintModes.cs
+++ b/KhTracker/Core/HintModes.cs
@@ -1557,14 +1557,11 @@ namespace KhTracker
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.TWTNW_ProgressionValues[prog - 1] + temp;
                 case "GoA":
-                    if (world.roomNumber == 32)
-                    {
-                        if (HashGrid.Visibility == Visibility.Visible)
-                        {
-                            HashGrid.Visibility = Visibility.Collapsed;
-                        }
-                    }
-                    return 0;
+                    if (data.WorldsData["HollowBastion"].complete && data.WorldsData["HollowBastion"].hintedProgression)
+                        temp = (data.HB_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                    else if (data.HB_ProgressionValues[prog - 1] > 0)
+                        data.WorldsData["HollowBastion"].worldGrid.WorldCompleteProgressionBonus();
+                    return data.CoR_ProgressionValues[prog - 1] + temp;
                 default: //return if any other world
                     return 0;
             }

--- a/KhTracker/Core/HintModes.cs
+++ b/KhTracker/Core/HintModes.cs
@@ -285,6 +285,10 @@ namespace KhTracker
                 SetWorldValue(data.WorldsData[key].value, 0);
             }
 
+            //locally track the worlds that are empty and contain the "has nothing, sorry" text
+            //then place these at the end of the hint list
+            List<Tuple<string, string, int>> tempReportInformation = new List<Tuple<string, string, int>>();
+            List<string> tempReportLocations = new List<string>();
             foreach (int hint in progHintsKeys)
             {
                 var hinttext = progHints[hint.ToString()]["Text"].ToString();
@@ -310,8 +314,24 @@ namespace KhTracker
                     }
                 }
 
-                data.reportInformation.Add(new Tuple<string, string, int>(hinttext, hintworld, hintproofs));
-                data.reportLocations.Add(location);
+                if (hinttext.Contains("has nothing, sorry"))
+                {
+                    tempReportInformation.Add(new Tuple<string, string, int>(hinttext, hintworld, hintproofs));
+                    tempReportLocations.Add(location);
+                }
+                else
+                {
+                    data.reportInformation.Add(new Tuple<string, string, int>(hinttext, hintworld, hintproofs));
+                    data.reportLocations.Add(location);
+                }
+            }
+
+            if (tempReportInformation.Count > 0)
+            {
+                foreach (var loc in tempReportInformation)
+                    data.reportInformation.Add(loc);
+                foreach (var loc in tempReportLocations)
+                    data.reportLocations.Add(loc);
             }
 
             //set pathproof defaults

--- a/KhTracker/Core/HintModes.cs
+++ b/KhTracker/Core/HintModes.cs
@@ -1479,10 +1479,10 @@ namespace KhTracker
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.HB_ProgressionValues[prog - 1] + temp;
                 case "CavernofRemembrance":
-                    if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
+                    if (data.WorldsData["HollowBastion"].complete && data.WorldsData["HollowBastion"].hintedProgression)
                         temp = (data.CoR_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.CoR_ProgressionValues[prog - 1] > 0)
-                        data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
+                        data.WorldsData["HollowBastion"].worldGrid.WorldCompleteProgressionBonus();
                     return data.CoR_ProgressionValues[prog - 1] + temp;
                 case "BeastsCastle":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
@@ -1557,11 +1557,12 @@ namespace KhTracker
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.TWTNW_ProgressionValues[prog - 1] + temp;
                 case "GoA":
-                    if (data.WorldsData["HollowBastion"].complete && data.WorldsData["HollowBastion"].hintedProgression)
-                        temp = (data.HB_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
-                    else if (data.HB_ProgressionValues[prog - 1] > 0)
-                        data.WorldsData["HollowBastion"].worldGrid.WorldCompleteProgressionBonus();
-                    return data.CoR_ProgressionValues[prog - 1] + temp;
+                    //if (data.WorldsData["HollowBastion"].complete && data.WorldsData["HollowBastion"].hintedProgression)
+                    //    temp = (data.HB_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                    //else if (data.HB_ProgressionValues[prog - 1] > 0)
+                    //    data.WorldsData["HollowBastion"].worldGrid.WorldCompleteProgressionBonus();
+                    //return data.CoR_ProgressionValues[prog - 1] + temp;
+                    return 0;
                 default: //return if any other world
                     return 0;
             }

--- a/KhTracker/Core/HintModes.cs
+++ b/KhTracker/Core/HintModes.cs
@@ -315,15 +315,10 @@ namespace KhTracker
                 }
 
                 if (hinttext.Contains("has nothing, sorry"))
-                {
                     tempReportInformation.Add(new Tuple<string, string, int>(hinttext, hintworld, hintproofs));
-                    tempReportLocations.Add(location);
-                }
                 else
-                {
                     data.reportInformation.Add(new Tuple<string, string, int>(hinttext, hintworld, hintproofs));
-                    data.reportLocations.Add(location);
-                }
+                data.reportLocations.Add(location);
             }
 
             if (tempReportInformation.Count > 0)

--- a/KhTracker/Core/HintModes.cs
+++ b/KhTracker/Core/HintModes.cs
@@ -1473,85 +1473,91 @@ namespace KhTracker
                     return data.STT_ProgressionValues[prog - 1] + temp;
                 case "TwilightTown":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
-                        temp = (data.STT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                        temp = (data.TT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.TT_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.TT_ProgressionValues[prog - 1] + temp;
                 case "HollowBastion":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
-                        temp = (data.STT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                        temp = (data.HB_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.HB_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.HB_ProgressionValues[prog - 1] + temp;
+                case "CavernofRemembrance":
+                    if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
+                        temp = (data.CoR_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                    else if (data.CoR_ProgressionValues[prog - 1] > 0)
+                        data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
+                    return data.CoR_ProgressionValues[prog - 1] + temp;
                 case "BeastsCastle":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
-                        temp = (data.STT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                        temp = (data.BC_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.BC_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.BC_ProgressionValues[prog - 1] + temp;
                 case "OlympusColiseum":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
-                        temp = (data.STT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                        temp = (data.OC_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.OC_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.OC_ProgressionValues[prog - 1] + temp;
                 case "Agrabah":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
-                        temp = (data.STT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                        temp = (data.AG_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.AG_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.AG_ProgressionValues[prog - 1] + temp;
                 case "LandofDragons":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
-                        temp = (data.STT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                        temp = (data.LoD_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.LoD_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.LoD_ProgressionValues[prog - 1] + temp;
                 case "HundredAcreWood":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
-                        temp = (data.STT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                        temp = (data.HAW_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.HAW_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.HAW_ProgressionValues[prog - 1] + temp;
                 case "PrideLands":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
-                        temp = (data.STT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                        temp = (data.PL_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.PL_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.PL_ProgressionValues[prog - 1] + temp;
                 case "Atlantica":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
-                        temp = (data.STT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                        temp = (data.AT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.AT_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.AT_ProgressionValues[prog - 1] + temp;
                 case "DisneyCastle":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
-                        temp = (data.STT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                        temp = (data.DC_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.DC_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.DC_ProgressionValues[prog - 1] + temp;
                 case "HalloweenTown":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
-                        temp = (data.STT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                        temp = (data.HT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.HT_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.HT_ProgressionValues[prog - 1] + temp;
                 case "PortRoyal":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
-                        temp = (data.STT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                        temp = (data.PR_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.PR_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.PR_ProgressionValues[prog - 1] + temp;
                 case "SpaceParanoids":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
-                        temp = (data.STT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                        temp = (data.SP_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.SP_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.SP_ProgressionValues[prog - 1] + temp;
                 case "TWTNW":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
-                        temp = (data.STT_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
+                        temp = (data.TWTNW_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.TWTNW_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
                     return data.TWTNW_ProgressionValues[prog - 1] + temp;

--- a/KhTracker/Core/Options.cs
+++ b/KhTracker/Core/Options.cs
@@ -1942,6 +1942,11 @@ namespace KhTracker
                                         foreach (int cost in setting.Value)
                                             data.HB_ProgressionValues.Add(cost);
                                         break;
+                                    case "CavernofRememberance":
+                                        data.CoR_ProgressionValues.Clear();
+                                        foreach (int cost in setting.Value)
+                                            data.CoR_ProgressionValues.Add(cost);
+                                        break;
                                     case "LandofDragons":
                                         data.LoD_ProgressionValues.Clear();
                                         foreach (int cost in setting.Value)

--- a/KhTracker/Core/Options.cs
+++ b/KhTracker/Core/Options.cs
@@ -1942,7 +1942,7 @@ namespace KhTracker
                                         foreach (int cost in setting.Value)
                                             data.HB_ProgressionValues.Add(cost);
                                         break;
-                                    case "CavernofRememberance":
+                                    case "CavernofRemembrance":
                                         data.CoR_ProgressionValues.Clear();
                                         foreach (int cost in setting.Value)
                                             data.CoR_ProgressionValues.Add(cost);

--- a/KhTracker/Core/Options.cs
+++ b/KhTracker/Core/Options.cs
@@ -687,6 +687,8 @@ namespace KhTracker
                 data.WorldsData[key].hinted = false;
                 data.WorldsData[key].hintedHint = false;
                 data.WorldsData[key].containsGhost = false;
+                //progression hints per world
+                data.WorldsData[key].hintedProgression = false;
             }
             data.WorldsData["GoA"].hinted = true;
 
@@ -1001,6 +1003,7 @@ namespace KhTracker
                 { "Atlantica", 0 },
                 { "PuzzSynth", 0 }
             };
+
 
             //unselect any currently selected world grid
             if (data.selected != null)
@@ -2022,6 +2025,9 @@ namespace KhTracker
                                         data.Drives_ProgressionValues.Clear();
                                         foreach (int cost in setting.Value)
                                             data.Drives_ProgressionValues.Add(cost);
+                                        break;
+                                    case "FinalXemnasReveal":
+                                        data.revealFinalXemnas = (setting.Value[0] == 0 ? false : true);
                                         break;
                                 }
                             }

--- a/KhTracker/MainWindow.xaml.cs
+++ b/KhTracker/MainWindow.xaml.cs
@@ -576,15 +576,22 @@ namespace KhTracker
 
         public void SetWorldValue(OutlinedTextBlock worldValue, int value)
         {
-            if (worldValue == null || worldValue.Name.Contains("GoA") ||
-                (data.UsingProgressionHints && !data.WorldsData[worldValue.Name.Substring(0, worldValue.Name.Length - 4)].hintedProgression))
-                return;
-
             string location = worldValue.Name.Substring(0, worldValue.Name.Length - 4);
             SolidColorBrush Color = (SolidColorBrush)FindResource("DefaultWhite"); //default
 
             if (data.WorldsData[location].containsGhost) //turn green if it conains ghost item
                 Color = (SolidColorBrush)FindResource("GhostHint");
+
+            if (worldValue == null || worldValue.Name.Contains("GoA") ||
+                (data.UsingProgressionHints && !data.WorldsData[worldValue.Name.Substring(0, worldValue.Name.Length - 4)].hintedProgression))
+            {
+                if (data.mode == Mode.DAHints)
+                {
+                    worldValue.Fill = Color;
+                }
+
+                return;
+            }
 
             if (data.WorldsData[location].complete) //turn blue if it's marked as hinted hint or complete
                 Color = (SolidColorBrush)FindResource("HintedHint");


### PR DESCRIPTION
When seeing the "<world> has nothing, sorry." hint text for Path Hints, that will be pushed to the end of the hint order