### PR TITLE
Auto Load Hints

### DIFF
--- a/KhTracker/App.config
+++ b/KhTracker/App.config
@@ -220,6 +220,9 @@
             <setting name="AutoSaveProgress2" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="AutoLoadHints" serializeAs="String">
+                <value>False</value>
+            </setting>
         </KhTracker.Properties.Settings>
     </userSettings>
   <runtime>

--- a/KhTracker/AutoTracking/AutoTracker.cs
+++ b/KhTracker/AutoTracking/AutoTracker.cs
@@ -606,7 +606,8 @@ namespace KhTracker
                 DeathCheck();
                 LevelsProgressionBonus();
                 DrivesProgressionBonus();
-                AddProgressionPoints(0);
+                if (LevelValue.Text == "1" && StrengthValue.Text == "0" && MagicValue.Text == "0")
+                    AddProgressionPoints(0);
 
                 if (data.mode == Mode.PointsHints || data.ScoreMode)
                 {

--- a/KhTracker/AutoTracking/AutoTracker.cs
+++ b/KhTracker/AutoTracking/AutoTracker.cs
@@ -606,6 +606,7 @@ namespace KhTracker
                 DeathCheck();
                 LevelsProgressionBonus();
                 DrivesProgressionBonus();
+                AddProgressionPoints(0);
 
                 if (data.mode == Mode.PointsHints || data.ScoreMode)
                 {

--- a/KhTracker/AutoTracking/AutoTracker.cs
+++ b/KhTracker/AutoTracking/AutoTracker.cs
@@ -178,7 +178,6 @@ namespace KhTracker
             if (checkedVer == 0) //no game was detected.
             {
                 //return and keep trying to connect if auto-connect is enabled.
-                if (AutoConnectOption.IsChecked) 
                 {
                     return;
                 }
@@ -190,7 +189,6 @@ namespace KhTracker
                     checkTimer.Stop();
                     checkTimer = null;
                     memory = null;
-                    if(data.usedHotkey)
                     {
                         MessageBox.Show("No game detected.\nPlease start KH2 before using Hotkey.");
                         data.usedHotkey = false;
@@ -202,14 +200,13 @@ namespace KhTracker
             else
             {
                 //if for some reason user starts playing an different version
-                if (data.lastVersion !=0 && data.lastVersion != checkedVer)
                 {
                     //reset tracker
                     OnReset(null, null);
                 }
 
                 //stop timer for checking game version
-                if (checkTimer!= null)
+                if (checkTimer != null)
                 {
                     checkTimer.Stop();
                     checkTimer = null;
@@ -466,7 +463,6 @@ namespace KhTracker
                 importantChecks.Add(finalReal = new DriveForm(memory, Save + 0x36C0, ADDRESS_OFFSET, 4, Save + 0x33D6, "FinalReal"));
                 importantChecks.Add(valorReal = new DriveForm(memory, Save + 0x36C0, ADDRESS_OFFSET, 1, Save + 0x32F6, Save + 0x06B2, "ValorReal"));
             }
-               
             int fireCount = fire != null ? fire.Level : 0;
             int blizzardCount = blizzard != null ? blizzard.Level : 0;
             int thunderCount = thunder != null ? thunder.Level : 0;
@@ -545,7 +541,6 @@ namespace KhTracker
             stats = new Stats(memory, ADDRESS_OFFSET, Save + 0x24FE, Slot1 + 0x188, Save + 0x3524, Save + 0x3700, NextSlot);
             rewards = new Rewards(memory, ADDRESS_OFFSET, Bt10);
 
-            if(!data.altFinalTracking)
                 checkEveryCheck = new CheckEveryCheck(memory, ADDRESS_OFFSET, Save, Sys3, Bt10, world, stats, rewards, valor, wisdom, limit, master, final);
 
 
@@ -591,14 +586,12 @@ namespace KhTracker
             try
             {
                 //current world
-                world.UpdateMemory();        
 
                 //test displaying sora's correct stats for PR 1st forsed fight
                 if (world.worldNum == 16 && world.roomNumber == 1 && (world.eventID1 == 0x33 || world.eventID1 == 0x34))
                     correctSlot = 2; //move forward this number of slots
 
                 //updates
-                stats.UpdateMemory(correctSlot);        
                 HighlightWorld(world);
                 UpdateStatValues();
                 UpdateWorldProgress(world, false, null);
@@ -609,7 +602,7 @@ namespace KhTracker
                 if (LevelValue.Text == "1" && StrengthValue.Text == "0" && MagicValue.Text == "0")
                     AddProgressionPoints(0);
 
-                if (data.mode == Mode.PointsHints || data.ScoreMode)
+                if (data.mode == Mode.PointsHints || data.ScoreMode || data.BossHomeHinting)
                 {
                     UpdatePointScore(0); //update score
                     GetBoss(world, false, null);
@@ -682,7 +675,7 @@ namespace KhTracker
                     data.usedHotkey = false;
                 }
 
-                if(AutoSaveProgress2Option.IsChecked)
+                if (AutoSaveProgress2Option.IsChecked)
                 {
                     if (!Directory.Exists("KhTrackerAutoSaves"))
                     {
@@ -859,7 +852,6 @@ namespace KhTracker
                 }
             }
         }
-        
         private void TrackQuantities()
         {
             while (fire.Level > fireLevel)
@@ -1144,7 +1136,6 @@ namespace KhTracker
                                     newProg = 11; //data demyx + sephi finished
                                 else if (curProg != 11) //just sephi
                                     newProg = 9;
-                                if(data.UsingProgressionHints)
                                 {
                                     UpdateProgressionPoints(wName, 9);
                                     updateProgressionPoints = false;
@@ -1590,19 +1581,6 @@ namespace KhTracker
 
                             }
                             break;
-                            //if (wID1 == 67 && wCom == 1) // Lingering Will finish
-                            //{
-                            //    if (curProg == 7)
-                            //        newProg = 9; //marluxia + LW finished
-                            //    else if (curProg != 9)
-                            //        newProg = 8;
-                            //    if (data.UsingProgressionHints)
-                            //    {
-                            //        UpdateProgressionPoints(wName, 9);
-                            //        updateProgressionPoints = false;
-                            //    }
-                            //}
-                            //break;
                         default:
                             updateProgression = false;
                             break;
@@ -2053,10 +2031,6 @@ namespace KhTracker
                             break;
                         case 4:
                             //Tutorial Seifer shouldn't give points
-                            //if (wID1 == 77) // Tutorial 4 - Fighting
-                            //    boss = "Seifer (1)";
-                            if (wID1 == 78) // Seifer I Battle
-                                boss = "Seifer (2)";
                             break;
                         case 5:
                             if (wID1 == 84) // Hayner Struggle
@@ -2414,9 +2388,6 @@ namespace KhTracker
                     break;
             }
 
-            //return if bo boss beaten found
-
-
             if (!usingSave)
             {
                 //if the boss was found and beaten then set flag
@@ -2429,11 +2400,9 @@ namespace KhTracker
 
             if (boss == "None")
                 return;
-                
             App.logger?.Record("Beaten Boss: " + boss);
 
             //get points for boss kills
-            GetBossPoints(boss);
 
             //add to log
             data.bossEventLog.Add(eventTuple);
@@ -2663,7 +2632,6 @@ namespace KhTracker
                         case "boss_datas":
                         case "boss_sephi":
                         case "boss_terra":
-                        //case "boss_final":
                             bonuspoints += data.PointsDatanew[bossType];
                             break;
                         case "boss_other":
@@ -2679,7 +2647,6 @@ namespace KhTracker
                     points = data.PointsDatanew[bossType];
 
                     //logging
-                    if(data.BossRandoFound)
                     {
                         App.logger?.Record("No replacement found? Boss: " + boss);
                     }
@@ -2725,11 +2692,9 @@ namespace KhTracker
             BindAbility(DodgeRoll, "Obtained", dodgeRoll);
             BindAbility(AerialDodge, "Obtained", aerialDodge);
             BindAbility(Glide, "Obtained", glide);
-            
             BindForm(WisdomM, "Obtained", wisdom);
             BindForm(LimitM, "Obtained", limit);
             BindForm(MasterM, "Obtained", master);
-            
             if (data.altFinalTracking)
             {
                 BindForm(ValorM, "Obtained", valorReal);

--- a/KhTracker/AutoTracking/AutoTracker.cs
+++ b/KhTracker/AutoTracking/AutoTracker.cs
@@ -437,6 +437,11 @@ namespace KhTracker
 
         private void FinishSetup(bool PCSX2, Int32 Now, Int32 Save, Int32 Sys3, Int32 Bt10, Int32 BtlEnd, Int32 Slot1, Int32 NextSlot)
         {
+            //Done here cause Valor and Final get detected otherwise
+            //only run if true
+            if (AutoLoadHintsOption.IsChecked)
+                AutoLoadHints();
+
             #region Add ICs
             importantChecks = new List<ImportantCheck>();
             importantChecks.Add(highJump = new Ability(memory, Save + 0x25CE, ADDRESS_OFFSET, 93, "HighJump"));

--- a/KhTracker/Core/Data.cs
+++ b/KhTracker/Core/Data.cs
@@ -195,6 +195,9 @@ namespace KhTracker
         public bool usedHotkey = false;
         public GlobalHotkey startAutoTracker1, startAutoTracker2;
         public GlobalHotkey scrollUp1, scrollUp2, scrollDown1, scrollDown2;
+
+        //BossHomeHinting TEST
+        public bool BossHomeHinting = false;
     }
 
     public class WorldData

--- a/KhTracker/Core/Data.cs
+++ b/KhTracker/Core/Data.cs
@@ -194,6 +194,7 @@ namespace KhTracker
         //Hotkey stuff
         public bool usedHotkey = false;
         public GlobalHotkey startAutoTracker1, startAutoTracker2;
+        public GlobalHotkey scrollUp1, scrollUp2, scrollDown1, scrollDown2;
     }
 
     public class WorldData

--- a/KhTracker/Core/HintModes.cs
+++ b/KhTracker/Core/HintModes.cs
@@ -1787,7 +1787,7 @@ namespace KhTracker
                         temp = (data.TWTNW_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.TWTNW_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
-                    return data.TWTNW_ProgressionValues[prog - 1] + temp + 90;
+                    return data.TWTNW_ProgressionValues[prog - 1] + temp;
                 case "GoA":
                     //if (data.WorldsData["HollowBastion"].complete && data.WorldsData["HollowBastion"].hintedProgression)
                     //    temp = (data.HB_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);

--- a/KhTracker/Core/HintModes.cs
+++ b/KhTracker/Core/HintModes.cs
@@ -1787,7 +1787,7 @@ namespace KhTracker
                         temp = (data.TWTNW_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.TWTNW_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
-                    return data.TWTNW_ProgressionValues[prog - 1] + temp;
+                    return data.TWTNW_ProgressionValues[prog - 1] + temp + 90;
                 case "GoA":
                     //if (data.WorldsData["HollowBastion"].complete && data.WorldsData["HollowBastion"].hintedProgression)
                     //    temp = (data.HB_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);

--- a/KhTracker/Core/HintModes.cs
+++ b/KhTracker/Core/HintModes.cs
@@ -1403,7 +1403,7 @@ namespace KhTracker
             data.TotalProgressionPoints += points;
 
             if (data.ProgressionCurrentHint >= data.HintCosts.Count - 1 || 
-                data.ProgressionCurrentHint == data.HintCosts.Count || data.ProgressionCurrentHint == data.WorldsEnabled)
+                data.ProgressionCurrentHint == data.HintCosts.Count || data.ProgressionCurrentHint == data.HintRevealOrder.Count)
             {
                 //update points anyway
                 ProgressionCollectedValue.Visibility = Visibility.Hidden;
@@ -1413,7 +1413,7 @@ namespace KhTracker
             }
 
             //loop in the event that one progression point rewards a lot
-            while (data.ProgressionPoints >= data.HintCosts[data.ProgressionCurrentHint] && data.ProgressionCurrentHint < data.HintCosts.Count && data.ProgressionCurrentHint < data.WorldsEnabled)
+            while (data.ProgressionPoints >= data.HintCosts[data.ProgressionCurrentHint] && data.ProgressionCurrentHint < data.HintCosts.Count && data.ProgressionCurrentHint < data.HintRevealOrder.Count)
             {
                 #region More Debug
                 //Console.WriteLine("Current Progression Hint = " + data.ProgressionCurrentHint);
@@ -1428,12 +1428,12 @@ namespace KhTracker
                 ProgressionReveal(data.ProgressionCurrentHint - 1);
 
                 if (data.ProgressionCurrentHint >= data.HintCosts.Count - 1 || data.ProgressionCurrentHint == data.HintCosts.Count || 
-                    data.ProgressionCurrentHint == data.WorldsEnabled) //revealed last hint
+                    data.ProgressionCurrentHint == data.HintRevealOrder.Count) //revealed last hint
                     break;
             }
 
             if (data.ProgressionCurrentHint >= data.HintCosts.Count - 1 || data.ProgressionCurrentHint == data.HintCosts.Count || 
-                data.ProgressionCurrentHint == data.WorldsEnabled)
+                data.ProgressionCurrentHint == data.HintRevealOrder.Count)
             {
                 //update points
                 ProgressionCollectedValue.Visibility = Visibility.Hidden;

--- a/KhTracker/Core/HintModes.cs
+++ b/KhTracker/Core/HintModes.cs
@@ -297,6 +297,20 @@ namespace KhTracker
             }
             catch { }
 
+            //BossHomeHinting TEST
+            try
+            {
+                var points = JsonSerializer.Deserialize<Dictionary<string, int>>(hintObject["checkValue"].ToString());
+
+                foreach (var point in points)
+                {
+                    if (point.Key == "boss_final" && point.Value == 269)
+                    {
+                        data.BossHomeHinting = true;
+                    }
+                }
+            }
+            catch { }
 
             //set if world value should change color on completion
             if (reveals.Contains("complete"))
@@ -312,7 +326,7 @@ namespace KhTracker
             }
 
             //reports reveal bosses
-            if(reveals.Contains("bossreports"))
+            if (reveals.Contains("bossreports"))
             {
                 //ReportsToggle(true);
                 TMP_bossReports = true;
@@ -398,7 +412,7 @@ namespace KhTracker
             {
                 //get random based on seed hash
                 Random rand = new Random(data.convertedSeedHash);
-                
+
                 //setup lists
                 List<string> keyList = new List<string>(data.BossList.Keys);
 
@@ -411,7 +425,7 @@ namespace KhTracker
                         keyList.Remove(key);
                         continue;
                     }
-                        
+
                     if (!data.enabledWorlds.Contains(Codes.bossLocations[key]))
                         keyList.Remove(key);
                     else if (key.Contains("(Data)"))
@@ -419,12 +433,12 @@ namespace KhTracker
                         //special case for some datas. we normally don't want
                         //to hint datas unless the world the normally are in is off
                         // (only applies for datas where the data fight is in a different world)
-                        switch(key)
+                        switch (key)
                         {
                             case "Axel (Data)":
                                 if (data.enabledWorlds.Contains("STT"))
                                     keyList.Remove(key);
-                            break;
+                                break;
                             case "Saix (Data)":
                             case "Luxord (Data)":
                             case "Roxas (Data)":
@@ -479,7 +493,7 @@ namespace KhTracker
 
                         worldhint = tmp_origBoss + " is unchanged";
                     }
-                    else 
+                    else
                     {
                         string tmp_origBoss = boss;
                         string tmp_replBoss = data.BossList[boss];
@@ -504,7 +518,7 @@ namespace KhTracker
 
                         worldhint = tmp_origBoss + " became " + tmp_replBoss;
                     }
-                    
+
                     int dummyvalue = -12345; //use this for boss reports i guess
                     data.reportInformation.Add(new Tuple<string, string, int>(worldhint, null, dummyvalue));
                     var location = Codes.ConvertSeedGenName(reports[report.ToString()]["Location"].ToString());
@@ -512,7 +526,7 @@ namespace KhTracker
 
                     keyList.Remove(boss);
                 }
-                
+
                 data.hintsLoaded = true;
             }
             else if (hintableItems.Contains("report"))
@@ -672,7 +686,7 @@ namespace KhTracker
                 }
                 foreach (var item in world.Value)
                 {
-                    
+
                     string itemName = item;
                     string itemType = Codes.FindItemType(item);
 
@@ -754,7 +768,7 @@ namespace KhTracker
 
         public void UpdatePointScore(int points)
         {
-            if (data.mode != Mode.PointsHints && !data.ScoreMode)
+            if (data.mode != Mode.PointsHints && !data.ScoreMode || data.BossHomeHinting)
                 return;
 
             int WorldBlue = 0;
@@ -1193,7 +1207,7 @@ namespace KhTracker
                         data.reportLocations.Add(location);
                         continue;
                     }
-                        
+
 
                     var worldhint = Codes.ConvertSeedGenName(worldstring);
                     location = Codes.ConvertSeedGenName(reports[report.ToString()]["Location"].ToString());
@@ -1501,8 +1515,8 @@ namespace KhTracker
             data.TotalProgressionPoints += points;
             data.calulating = true;
 
-            if (data.ProgressionCurrentHint >= data.HintCosts.Count - 1 || 
-                data.ProgressionCurrentHint == data.HintCosts.Count || data.ProgressionCurrentHint == data.HintRevealOrder.Count)
+            if (data.ProgressionCurrentHint >= data.HintCosts.Count - 1 ||
+                data.ProgressionCurrentHint == data.HintCosts.Count || data.ProgressionCurrentHint == data.WorldsEnabled)
             {
                 //update points anyway
                 //ProgressionCollectedValue.Visibility = Visibility.Hidden;
@@ -1514,7 +1528,7 @@ namespace KhTracker
             }
 
             //loop in the event that one progression point rewards a lot
-            while (data.ProgressionPoints >= data.HintCosts[data.ProgressionCurrentHint] && data.ProgressionCurrentHint < data.HintCosts.Count && data.ProgressionCurrentHint < data.HintRevealOrder.Count)
+            while (data.ProgressionPoints >= data.HintCosts[data.ProgressionCurrentHint] && data.ProgressionCurrentHint < data.HintCosts.Count && data.ProgressionCurrentHint < data.WorldsEnabled)
             {
                 #region More Debug
                 //Console.WriteLine("Current Progression Hint = " + data.ProgressionCurrentHint);
@@ -1528,13 +1542,13 @@ namespace KhTracker
                 //reveal hints/world
                 worldsRevealed.Add(ProgressionReveal(data.ProgressionCurrentHint - 1));
 
-                if (data.ProgressionCurrentHint >= data.HintCosts.Count - 1 || data.ProgressionCurrentHint == data.HintCosts.Count || 
-                    data.ProgressionCurrentHint == data.HintRevealOrder.Count) //revealed last hint
+                if (data.ProgressionCurrentHint >= data.HintCosts.Count - 1 || data.ProgressionCurrentHint == data.HintCosts.Count ||
+                    data.ProgressionCurrentHint == data.WorldsEnabled) //revealed last hint
                     break;
             }
 
-            if (data.ProgressionCurrentHint >= data.HintCosts.Count - 1 || data.ProgressionCurrentHint == data.HintCosts.Count || 
-                data.ProgressionCurrentHint == data.HintRevealOrder.Count)
+            if (data.ProgressionCurrentHint >= data.HintCosts.Count - 1 || data.ProgressionCurrentHint == data.HintCosts.Count ||
+                data.ProgressionCurrentHint == data.WorldsEnabled)
             {
                 //update points
                 //ProgressionCollectedValue.Visibility = Visibility.Hidden;
@@ -1727,7 +1741,7 @@ namespace KhTracker
                         temp = (data.OC_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.OC_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
-                    return data.OC_ProgressionValues[prog - 1] + temp;
+                    return data.OC_ProgressionValues[prog - 1] + temp + 17;
                 case "Agrabah":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
                         temp = (data.AG_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
@@ -1799,9 +1813,15 @@ namespace KhTracker
                     return 0;
             }
         }
-    
+
         public void ProgressionBossHints()
         {
+            if (data.BossHomeHinting)
+            {
+                BossHomeHinting();
+                return;
+            }
+
             data.progBossInformation.Clear();
             int TempCost = data.HintCosts[0];
 
@@ -1876,10 +1896,10 @@ namespace KhTracker
                         tmp_origBoss = "Pete";
                     }
 
-                    if (tmp_origBoss.EndsWith(" (1)") || tmp_origBoss.EndsWith(" (2)") || 
+                    if (tmp_origBoss.EndsWith(" (1)") || tmp_origBoss.EndsWith(" (2)") ||
                         tmp_origBoss.EndsWith(" (3)") || tmp_origBoss.EndsWith(" (4)"))
                     {
-                        tmp_origBoss = tmp_origBoss.Substring(0, tmp_origBoss.Length-4);
+                        tmp_origBoss = tmp_origBoss.Substring(0, tmp_origBoss.Length - 4);
                     }
 
                     BossA = tmp_origBoss;
@@ -1936,5 +1956,85 @@ namespace KhTracker
             data.HintCosts.Add(TempCost);
         }
 
+        //TEST
+        public void BossHomeHinting()
+        {
+            data.progBossInformation.Clear();
+            int TempCost = data.HintCosts[0];
+            data.HintCosts = new List<int>();
+            data.WorldsEnabled = data.BossList.Count + 1;
+
+            for (int i = 0; i < data.WorldsEnabled; ++i)
+            {
+                data.HintCosts.Add(TempCost);
+            }
+            data.HintCosts.Add(TempCost);
+
+            for (int i = 0; i < data.STT_ProgressionValues.Count; ++i)
+            {
+                data.STT_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.TT_ProgressionValues.Count; ++i)
+            {
+                data.TT_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.HB_ProgressionValues.Count; ++i)
+            {
+                data.HB_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.CoR_ProgressionValues.Count; ++i)
+            {
+                data.CoR_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.BC_ProgressionValues.Count; ++i)
+            {
+                data.BC_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.OC_ProgressionValues.Count; ++i)
+            {
+                data.OC_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.AG_ProgressionValues.Count; ++i)
+            {
+                data.AG_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.LoD_ProgressionValues.Count; ++i)
+            {
+                data.LoD_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.HAW_ProgressionValues.Count; ++i)
+            {
+                data.HAW_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.PL_ProgressionValues.Count; ++i)
+            {
+                data.PL_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.AT_ProgressionValues.Count; ++i)
+            {
+                data.AT_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.DC_ProgressionValues.Count; ++i)
+            {
+                data.DC_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.HT_ProgressionValues.Count; ++i)
+            {
+                data.HT_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.PR_ProgressionValues.Count; ++i)
+            {
+                data.PR_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.SP_ProgressionValues.Count; ++i)
+            {
+                data.SP_ProgressionValues[i] = 0;
+            }
+            for (int i = 0; i < data.TWTNW_ProgressionValues.Count; ++i)
+            {
+                data.TWTNW_ProgressionValues[i] = 0;
+            }
+
+        }
     }
 }

--- a/KhTracker/Core/HintModes.cs
+++ b/KhTracker/Core/HintModes.cs
@@ -165,13 +165,17 @@ namespace KhTracker
             List<int> reportKeys = reports.Keys.Select(int.Parse).ToList();
             reportKeys.Sort();
 
+            int synthCount = 0;
             foreach (var report in reportKeys)
             {
                 var world = Codes.ConvertSeedGenName(reports[report.ToString()]["World"].ToString());
                 if (data.UsingProgressionHints && !data.puzzlesOn && world.ToString().Contains("PuzzSynth"))
+                {
+                    synthCount++;
                     continue;
+                }
                 var count = reports[report.ToString()]["Count"].ToString();
-                var location = Codes.ConvertSeedGenName(reports[report.ToString()]["Location"].ToString());
+                var location = Codes.ConvertSeedGenName(reports[(report - synthCount).ToString()]["Location"].ToString());
                 data.reportInformation.Add(new Tuple<string, string, int>(null, world, int.Parse(count)));
                 data.reportLocations.Add(location);
             }

--- a/KhTracker/Core/HintModes.cs
+++ b/KhTracker/Core/HintModes.cs
@@ -1741,7 +1741,7 @@ namespace KhTracker
                         temp = (data.OC_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);
                     else if (data.OC_ProgressionValues[prog - 1] > 0)
                         data.WorldsData[worldName].worldGrid.WorldCompleteProgressionBonus();
-                    return data.OC_ProgressionValues[prog - 1] + temp + 17;
+                    return data.OC_ProgressionValues[prog - 1] + temp;
                 case "Agrabah":
                     if (data.WorldsData[worldName].complete && data.WorldsData[worldName].hintedProgression)
                         temp = (data.AG_ProgressionValues[prog - 1] > 0 ? data.WorldCompleteBonus : 0);

--- a/KhTracker/Core/Options.cs
+++ b/KhTracker/Core/Options.cs
@@ -595,7 +595,7 @@ namespace KhTracker
                         //    AbilitiesToggle(false);
 
                         //prevent creations hinting twice for progression
-                        if (puzzleOn)
+                        if ((puzzleOn || hintObject["hintsType"].ToString() == "Path") && !data.HintRevealOrder.Contains("PuzzSynth"))
                         {
                             data.HintRevealOrder.Add("PuzzSynth");
                         }
@@ -2510,7 +2510,7 @@ namespace KhTracker
                             //    AbilitiesToggle(false);
 
                             //prevent creations hinting twice for progression
-                            if (puzzleOn)
+                            if ((puzzleOn || hintObject["hintsType"].ToString() == "Path") && !data.HintRevealOrder.Contains("PuzzSynth"))
                             {
                                 data.HintRevealOrder.Add("PuzzSynth");
                             }

--- a/KhTracker/Core/Options.cs
+++ b/KhTracker/Core/Options.cs
@@ -3040,6 +3040,18 @@ namespace KhTracker
             }
         }
 
+        private void ProgScrollHotkey()
+        {
+            data.scrollUp1 = new GlobalHotkey(ModifierKeys.Control, Key.Up, GoAScrollUp);
+            HotkeysManager.AddHotkey(data.scrollUp1);
+            data.scrollDown1 = new GlobalHotkey(ModifierKeys.Control, Key.Down, GoAScrollDown);
+            HotkeysManager.AddHotkey(data.scrollDown1);
+            data.scrollUp2 = new GlobalHotkey(ModifierKeys.None, Key.PageUp, GoAScrollUp);
+            HotkeysManager.AddHotkey(data.scrollUp2);
+            data.scrollDown2 = new GlobalHotkey(ModifierKeys.None, Key.PageDown, GoAScrollDown);
+            HotkeysManager.AddHotkey(data.scrollDown2);
+        }
+
         private string UpperCaseFirst(string word)
         {
             if (word.Length <= 0)

--- a/KhTracker/Core/Options.cs
+++ b/KhTracker/Core/Options.cs
@@ -1430,6 +1430,9 @@ namespace KhTracker
                         case "sys.yml":
                             hashfileBackup = entry;
                             break;
+                        //case "bosshintshome.txt":
+                        //    data.BossHomeHinting = true;
+                        //    break;
                         default:
                             break;
                     }
@@ -2347,6 +2350,8 @@ namespace KhTracker
             data.hintsLoaded = false;
             data.seedLoaded = false;
             data.saveFileLoaded = false;
+
+            data.BossHomeHinting = false;
 
             //prog boss hint stuff
             BossHintTextMiddle.Text = "";

--- a/KhTracker/Core/Options.cs
+++ b/KhTracker/Core/Options.cs
@@ -2053,7 +2053,8 @@ namespace KhTracker
             }
         }
 
-        //Same as OpenKHSeed but uses a directory of an extracted folder
+        //Essentually same as OpenKHSeed but uses the OpenKH Mod Manager directory
+        //instead of extracting a zip
         //Initially meant for use with AutoLoadHints
         private void OpenKHSeedExtracted(string dir)
         {

--- a/KhTracker/Core/Options.cs
+++ b/KhTracker/Core/Options.cs
@@ -2036,6 +2036,8 @@ namespace KhTracker
                                 break;
                         }
 
+                        data.hintsLoaded = true;
+
                         reader.Close();
                     }
                 }
@@ -2049,6 +2051,654 @@ namespace KhTracker
             {
                 InitTracker();
             }
+        }
+
+        //Same as OpenKHSeed but uses a directory of an extracted folder
+        //Initially meant for use with AutoLoadHints
+        private void OpenKHSeedExtracted(string dir)
+        {
+            //Get the file locations of the respective files first
+            string hintsfile = null;
+            string hashfile = null;
+            string hashfileBackup = null;
+            string enemyfile = null;
+
+            //Scan all files in the directory/subdirectory 1 at a time like the zip version
+            string[] allFiles = System.IO.Directory.GetFiles(dir, "*.*", SearchOption.AllDirectories);
+            foreach (string file in allFiles)
+            {
+                //Check if the needed tracker file types are detected
+                if (file.Contains("HintFile.Hints"))
+                {
+                    hintsfile = file;
+                    //Console.WriteLine("Found hint file = " + hintsfile);
+                }
+                else if (file.Contains("enemies.rando"))
+                {
+                    enemyfile = file;
+                    //Console.WriteLine("Found enemies.rando file = " + enemyfile);
+                }
+                else if (file.Contains("randoseed-hash-icons.csv"))
+                {
+                    hashfile = file;
+                    //Console.WriteLine("Found hash csv file = " + hashfile);
+                }
+                else if (file.Contains("sys.yml"))
+                {
+                    hashfileBackup = file;
+                    //Console.WriteLine("Found hashbackup file = " + hashfileBackup);
+                }
+            }
+
+            if (enemyfile != null)
+            {
+                using (var reader3 = new StreamReader(enemyfile))
+                {
+                    data.BossRandoFound = true;
+                    data.openKHBossText = reader3.ReadToEnd();
+                    var enemyText = Encoding.UTF8.GetString(Convert.FromBase64String(data.openKHBossText));
+                    try
+                    {
+                        var enemyObject = JsonSerializer.Deserialize<Dictionary<string, object>>(enemyText);
+                        var bosses = JsonSerializer.Deserialize<List<Dictionary<string, object>>>(enemyObject["BOSSES"].ToString());
+
+                        foreach (var bosspair in bosses)
+                        {
+                            string bossOrig = bosspair["original"].ToString();
+                            string bossRepl = bosspair["new"].ToString();
+
+                            data.BossList.Add(bossOrig, bossRepl);
+                        }
+                    }
+                    catch
+                    {
+                        data.BossRandoFound = false;
+                        data.openKHBossText = "None";
+                        App.logger?.Record("error while trying to parse bosses.");
+                    }
+
+                    reader3.Close();
+                }
+            }
+
+            if (hashfile != null || hashfileBackup != null)
+            {
+                string[] hash = null;
+                //new method
+                if (hashfile != null)
+                {
+                    Console.WriteLine("Meow");
+                    using (var reader = new StreamReader(hashfile))
+                    {
+                        string[] separatingStrings = { "," };
+                        string text = reader.ReadToEnd();
+                        hash = text.Split(separatingStrings, System.StringSplitOptions.RemoveEmptyEntries);
+                        reader.Close();
+                    }
+                }
+                //old method
+                else if (hashfileBackup != null)
+                {
+                    using (var readerB = new StreamReader(hashfileBackup))
+                    {
+                        string[] separatingStrings = { "- en: ", " ", "'", "{", "}", ":", "icon" };
+                        string text1 = readerB.ReadLine();
+                        string text2 = readerB.ReadLine();
+                        string text = text1 + text2;
+                        hash = text.Split(separatingStrings, System.StringSplitOptions.RemoveEmptyEntries);
+                        readerB.Close();
+                    }
+                }
+                //load hash visual
+                if (hash != null)
+                {
+                    //Set Icons
+                    HashIcon1.SetResourceReference(ContentProperty, hash[0]);
+                    HashIcon2.SetResourceReference(ContentProperty, hash[1]);
+                    HashIcon3.SetResourceReference(ContentProperty, hash[2]);
+                    HashIcon4.SetResourceReference(ContentProperty, hash[3]);
+                    HashIcon5.SetResourceReference(ContentProperty, hash[4]);
+                    HashIcon6.SetResourceReference(ContentProperty, hash[5]);
+                    HashIcon7.SetResourceReference(ContentProperty, hash[6]);
+                    data.SeedHashLoaded = true;
+                    data.seedHashVisual = hash;
+
+                    //make visible
+                    if (SeedHashOption.IsChecked)
+                    {
+                        SetHintText("");
+                        HashGrid.Visibility = Visibility.Visible;
+                    }
+
+                    HashToSeed(hash);
+                }
+            }
+
+            if (hintsfile != null)
+            {
+                using (StreamReader reader = new StreamReader(hintsfile))
+                {
+                    data.openKHHintText = reader.ReadToEnd();
+                    var hintText = Encoding.UTF8.GetString(Convert.FromBase64String(data.openKHHintText));
+                    var hintObject = JsonSerializer.Deserialize<Dictionary<string, object>>(hintText);
+                    var settings = new List<string>();
+                    var hintableItems = new List<string>();
+                    //fallback for older seeds
+                    try
+                    {
+                        hintableItems = new List<string>(JsonSerializer.Deserialize<List<string>>(hintObject["hintableItems"].ToString()));
+                    }
+                    catch { }
+
+                    data.ShouldResetHash = false;
+
+                    //if (hintObject.ContainsKey("generatorVersion"))
+                    //{
+                    //    data.seedgenVersion = hintObject["generatorVersion"].ToString();
+                    //}
+
+                    if (hintObject.ContainsKey("settings"))
+                    {
+                        settings = JsonSerializer.Deserialize<List<string>>(hintObject["settings"].ToString());
+
+                        #region Settings
+
+                        TornPagesToggle(false);
+                        AbilitiesToggle(false);
+                        ReportsToggle(false);
+                        ExtraChecksToggle(false);
+                        VisitLockToggle(false);
+                        foreach (string item in hintableItems)
+                        {
+                            switch (item)
+                            {
+                                case "magic":
+                                    break;
+                                case "form":
+                                    break;
+                                case "summon":
+                                    break;
+                                case "page":
+                                    TornPagesToggle(true);
+                                    break;
+                                case "ability":
+                                    AbilitiesToggle(true);
+                                    break;
+                                case "report":
+                                    ReportsToggle(true);
+                                    break;
+                                case "other":
+                                    ExtraChecksToggle(true);
+                                    break;
+                                case "visit":
+                                    VisitLockToggle(true);
+                                    break;
+                                case "proof":
+                                    break;
+                            }
+                        }
+
+                        //if (hintableItems.Contains("report"))
+                        //    ReportsToggle(true);
+                        //else
+                        //    ReportsToggle(false);
+                        //
+                        //if (hintableItems.Contains("page"))
+                        //    TornPagesToggle(true);
+                        //else
+                        //    TornPagesToggle(false);
+                        //
+                        //if (hintableItems.Contains("ability"))
+                        //    AbilitiesToggle(true);
+                        //else
+                        //    AbilitiesToggle(false);
+                        //
+                        //if (hintableItems.Count == 0)
+                        //{
+                        //    ReportsToggle(true);
+                        //    TornPagesToggle(true);
+                        //    AbilitiesToggle(true);
+                        //}
+
+                        //item settings
+                        PromiseCharmToggle(false);
+                        //AbilitiesToggle(false);
+                        //VisitLockToggle(false);
+                        //ExtraChecksToggle(false);
+                        AntiFormToggle(false);
+
+                        //world settings
+                        SoraHeartToggle(true);
+                        DrivesToggle(false);
+                        SimulatedToggle(false);
+                        TwilightTownToggle(false);
+                        HollowBastionToggle(false);
+                        BeastCastleToggle(false);
+                        OlympusToggle(false);
+                        AgrabahToggle(false);
+                        LandofDragonsToggle(false);
+                        DisneyCastleToggle(false);
+                        PrideLandsToggle(false);
+                        PortRoyalToggle(false);
+                        HalloweenTownToggle(false);
+                        SpaceParanoidsToggle(false);
+                        TWTNWToggle(false);
+                        HundredAcreWoodToggle(false);
+                        AtlanticaToggle(false);
+                        PuzzleToggle(false);
+                        SynthToggle(false);
+
+                        //progression hints GoA Current Hint Count
+                        data.WorldsData["GoA"].value.Visibility = Visibility.Hidden;
+
+                        //settings visuals
+                        SettingRow.Height = new GridLength(0.5, GridUnitType.Star);
+                        Setting_BetterSTT.Width = new GridLength(0, GridUnitType.Star);
+                        Setting_Level_01.Width = new GridLength(0, GridUnitType.Star);
+                        Setting_Level_50.Width = new GridLength(0, GridUnitType.Star);
+                        Setting_Level_99.Width = new GridLength(0, GridUnitType.Star);
+                        Setting_Absent.Width = new GridLength(0, GridUnitType.Star);
+                        Setting_Absent_Split.Width = new GridLength(0, GridUnitType.Star);
+                        Setting_Datas.Width = new GridLength(0, GridUnitType.Star);
+                        Setting_Sephiroth.Width = new GridLength(0, GridUnitType.Star);
+                        Setting_Terra.Width = new GridLength(0, GridUnitType.Star);
+                        Setting_Cups.Width = new GridLength(0, GridUnitType.Star);
+                        Setting_HadesCup.Width = new GridLength(0, GridUnitType.Star);
+                        Setting_Cavern.Width = new GridLength(0, GridUnitType.Star);
+                        Setting_Transport.Width = new GridLength(0, GridUnitType.Star);
+                        Double SpacerValue = 10;
+                        #endregion
+
+                        //to be safe about this i guess
+                        //bool abilitiesOn = true;
+                        bool puzzleOn = false;
+                        bool synthOn = false;
+
+                        //load settings from hints
+                        foreach (string setting in settings)
+                        {
+                            Console.WriteLine("setting found = " + setting);
+
+                            switch (setting)
+                            {
+                                //items
+                                case "PromiseCharm":
+                                    PromiseCharmToggle(true);
+                                    break;
+                                //case "Level1Mode":
+                                //    abilitiesOn = false;
+                                //    break;
+                                case "visit_locking":
+                                    VisitLockToggle(true);
+                                    break;
+                                //case "extra_ics":
+                                //    ExtraChecksToggle(true);
+                                //    break;
+                                case "Anti-Form":
+                                    AntiFormToggle(true);
+                                    break;
+                                //worlds
+                                case "Level":
+                                    SoraHeartToggle(false);
+                                    SoraLevel01Toggle(true);
+                                    //AbilitiesToggle(true);
+                                    Setting_Level_01.Width = new GridLength(1.5, GridUnitType.Star);
+                                    SpacerValue--;
+                                    break;
+                                case "ExcludeFrom50":
+                                    SoraLevel50Toggle(true);
+                                    //AbilitiesToggle(true);
+                                    Setting_Level_50.Width = new GridLength(1.5, GridUnitType.Star);
+                                    SpacerValue--;
+                                    data.HintRevealOrder.Add("SorasHeart");
+                                    break;
+                                case "ExcludeFrom99":
+                                    SoraLevel99Toggle(true);
+                                    //AbilitiesToggle(true);
+                                    Setting_Level_99.Width = new GridLength(1.5, GridUnitType.Star);
+                                    SpacerValue--;
+                                    data.HintRevealOrder.Add("SorasHeart");
+                                    break;
+                                case "Simulated Twilight Town":
+                                    SimulatedToggle(true);
+                                    data.enabledWorlds.Add("STT");
+                                    data.HintRevealOrder.Add("SimulatedTwilightTown");
+                                    break;
+                                case "Hundred Acre Wood":
+                                    HundredAcreWoodToggle(true);
+                                    data.enabledWorlds.Add("HundredAcreWood");
+                                    data.HintRevealOrder.Add("HundredAcreWood");
+                                    break;
+                                case "Atlantica":
+                                    AtlanticaToggle(true);
+                                    data.enabledWorlds.Add("Atlantica");
+                                    data.HintRevealOrder.Add("Atlantica");
+                                    break;
+                                case "Puzzle":
+                                    PuzzleToggle(true);
+                                    puzzleOn = true;
+                                    data.puzzlesOn = true;
+                                    break;
+                                case "Synthesis":
+                                    SynthToggle(true);
+                                    synthOn = true;
+                                    data.synthOn = true;
+                                    break;
+                                case "Form Levels":
+                                    DrivesToggle(true);
+                                    data.HintRevealOrder.Add("DriveForms");
+                                    break;
+                                case "Land of Dragons":
+                                    LandofDragonsToggle(true);
+                                    data.enabledWorlds.Add("LoD");
+                                    data.HintRevealOrder.Add("LandofDragons");
+                                    break;
+                                case "Beast's Castle":
+                                    BeastCastleToggle(true);
+                                    data.enabledWorlds.Add("BC");
+                                    data.HintRevealOrder.Add("BeastsCastle");
+                                    break;
+                                case "Hollow Bastion":
+                                    HollowBastionToggle(true);
+                                    data.enabledWorlds.Add("HB");
+                                    data.HintRevealOrder.Add("HollowBastion");
+                                    break;
+                                case "Twilight Town":
+                                    TwilightTownToggle(true);
+                                    data.enabledWorlds.Add("TT");
+                                    data.HintRevealOrder.Add("TwilightTown");
+                                    break;
+                                case "The World That Never Was":
+                                    TWTNWToggle(true);
+                                    data.enabledWorlds.Add("TWTNW");
+                                    data.HintRevealOrder.Add("TWTNW");
+                                    break;
+                                case "Space Paranoids":
+                                    SpaceParanoidsToggle(true);
+                                    data.enabledWorlds.Add("SP");
+                                    data.HintRevealOrder.Add("SpaceParanoids");
+                                    break;
+                                case "Port Royal":
+                                    PortRoyalToggle(true);
+                                    data.enabledWorlds.Add("PR");
+                                    data.HintRevealOrder.Add("PortRoyal");
+                                    break;
+                                case "Olympus Coliseum":
+                                    OlympusToggle(true);
+                                    data.enabledWorlds.Add("OC");
+                                    data.HintRevealOrder.Add("OlympusColiseum");
+                                    break;
+                                case "Agrabah":
+                                    AgrabahToggle(true);
+                                    data.enabledWorlds.Add("AG");
+                                    data.HintRevealOrder.Add("Agrabah");
+                                    break;
+                                case "Halloween Town":
+                                    HalloweenTownToggle(true);
+                                    data.enabledWorlds.Add("HT");
+                                    data.HintRevealOrder.Add("HalloweenTown");
+                                    break;
+                                case "Pride Lands":
+                                    PrideLandsToggle(true);
+                                    data.enabledWorlds.Add("PL");
+                                    data.HintRevealOrder.Add("PrideLands");
+                                    break;
+                                case "Disney Castle / Timeless River":
+                                    DisneyCastleToggle(true);
+                                    data.enabledWorlds.Add("DC");
+                                    data.HintRevealOrder.Add("DisneyCastle");
+                                    break;
+                                //settings
+                                case "better_stt":
+                                    Setting_BetterSTT.Width = new GridLength(1.1, GridUnitType.Star);
+                                    SpacerValue--;
+                                    break;
+                                case "Cavern of Remembrance":
+                                    Setting_Cavern.Width = new GridLength(1, GridUnitType.Star);
+                                    SpacerValue--;
+                                    break;
+                                case "Data Split":
+                                    Setting_Absent_Split.Width = new GridLength(1, GridUnitType.Star);
+                                    SpacerValue--;
+                                    data.dataSplit = true;
+                                    break;
+                                case "Absent Silhouettes":
+                                    if (!data.dataSplit) //only use if we didn't already set the data split version
+                                    {
+                                        Setting_Absent.Width = new GridLength(1, GridUnitType.Star);
+                                        SpacerValue--;
+                                    }
+                                    break;
+                                case "Sephiroth":
+                                    Setting_Sephiroth.Width = new GridLength(1, GridUnitType.Star);
+                                    SpacerValue--;
+                                    break;
+                                case "Lingering Will (Terra)":
+                                    Setting_Terra.Width = new GridLength(1, GridUnitType.Star);
+                                    SpacerValue--;
+                                    break;
+                                case "Data Organization XIII":
+                                    Setting_Datas.Width = new GridLength(1, GridUnitType.Star);
+                                    SpacerValue--;
+                                    break;
+                                case "Transport to Remembrance":
+                                    Setting_Transport.Width = new GridLength(1, GridUnitType.Star);
+                                    SpacerValue--;
+                                    break;
+                                case "Olympus Cups":
+                                    Setting_Cups.Width = new GridLength(1, GridUnitType.Star);
+                                    SpacerValue--;
+                                    break;
+                                case "Hades Paradox Cup":
+                                    Setting_HadesCup.Width = new GridLength(1, GridUnitType.Star);
+                                    SpacerValue--;
+                                    break;
+                                case "ScoreMode":
+                                    data.ScoreMode = true;
+                                    break;
+                                //progression hints
+                                case "ProgressionHints":
+                                    data.UsingProgressionHints = true;
+                                    data.WorldsData["GoA"].value.Visibility = Visibility.Visible;
+                                    data.WorldsData["GoA"].value.Text = "0";
+                                    //Console.WriteLine("ENABLING PROGRESSION HINTS");
+                                    break;
+                                case "dummy_forms":
+                                    data.altFinalTracking = true;
+                                    break;
+                            }
+                        }
+
+                        //if (abilitiesOn == false)
+                        //    AbilitiesToggle(false);
+
+                        //prevent creations hinting twice for progression
+                        if ((puzzleOn || hintObject["hintsType"].ToString() == "Path") && !data.HintRevealOrder.Contains("PuzzSynth"))
+                        {
+                            data.HintRevealOrder.Add("PuzzSynth");
+                        }
+
+                        Setting_Spacer.Width = new GridLength(SpacerValue, GridUnitType.Star);
+                        SettingsText.Text = "Settings:";
+
+                    }
+
+                    if (hintObject.ContainsKey("ProgressionType"))
+                    {
+                        data.progressionType = hintObject["ProgressionType"].ToString();
+                    }
+
+                    if (hintObject.ContainsKey("ProgressionSettings"))
+                    {
+                        var progressionSettings = JsonSerializer.Deserialize<Dictionary<string, List<int>>>(hintObject["ProgressionSettings"].ToString());
+
+                        if (data.progressionType == "Disabled")
+                            data.progressionType = "Reports";
+
+                        foreach (var setting in progressionSettings)
+                        {
+                            //Console.WriteLine("progression setting found = " + setting.Key);
+
+                            switch (setting.Key)
+                            {
+                                case "HintCosts":
+                                    data.HintCosts.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.HintCosts.Add(cost);
+                                    data.HintCosts.Add(data.HintCosts[data.HintCosts.Count - 1] + 1); //duplicates the last cost for logic reasons
+                                    break;
+                                case "SimulatedTwilightTown":
+                                    data.STT_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.STT_ProgressionValues.Add(cost);
+                                    break;
+                                case "TwilightTown":
+                                    data.TT_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.TT_ProgressionValues.Add(cost);
+                                    break;
+                                case "HollowBastion":
+                                    data.HB_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.HB_ProgressionValues.Add(cost);
+                                    break;
+                                case "CavernofRemembrance":
+                                    data.CoR_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.CoR_ProgressionValues.Add(cost);
+                                    break;
+                                case "LandofDragons":
+                                    data.LoD_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.LoD_ProgressionValues.Add(cost);
+                                    break;
+                                case "BeastsCastle":
+                                    data.BC_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.BC_ProgressionValues.Add(cost);
+                                    break;
+                                case "OlympusColiseum":
+                                    data.OC_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.OC_ProgressionValues.Add(cost);
+                                    break;
+                                case "DisneyCastle":
+                                    data.DC_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.DC_ProgressionValues.Add(cost);
+                                    break;
+                                case "Agrabah":
+                                    data.AG_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.AG_ProgressionValues.Add(cost);
+                                    break;
+                                case "PortRoyal":
+                                    data.PR_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.PR_ProgressionValues.Add(cost);
+                                    break;
+                                case "HalloweenTown":
+                                    data.HT_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.HT_ProgressionValues.Add(cost);
+                                    break;
+                                case "PrideLands":
+                                    data.PL_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.PL_ProgressionValues.Add(cost);
+                                    break;
+                                case "HundredAcreWood":
+                                    data.HAW_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.HAW_ProgressionValues.Add(cost);
+                                    break;
+                                case "SpaceParanoids":
+                                    data.SP_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.SP_ProgressionValues.Add(cost);
+                                    break;
+                                case "TWTNW":
+                                    data.TWTNW_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.TWTNW_ProgressionValues.Add(cost);
+                                    break;
+                                case "Atlantica":
+                                    data.AT_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.AT_ProgressionValues.Add(cost);
+                                    break;
+                                case "ReportBonus":
+                                    data.ReportBonus = setting.Value[0];
+                                    break;
+                                case "WorldCompleteBonus":
+                                    data.WorldCompleteBonus = setting.Value[0];
+                                    break;
+                                case "Levels":
+                                    data.Levels_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.Levels_ProgressionValues.Add(cost);
+                                    break;
+                                case "Drives":
+                                    data.Drives_ProgressionValues.Clear();
+                                    foreach (int cost in setting.Value)
+                                        data.Drives_ProgressionValues.Add(cost);
+                                    break;
+                                case "FinalXemnasReveal":
+                                    data.revealFinalXemnas = setting.Value[0] == 0 ? false : true;
+                                    break;
+                            }
+                        }
+                        //data.NumOfHints = data.HintCosts.Count;
+                        //set text correctly
+                        ProgressionCollectedValue.Visibility = Visibility.Visible;
+                        ProgressionCollectedBar.Visibility = Visibility.Visible;
+                        ProgressionCollectedValue.Text = "0";
+                        ProgressionTotalValue.Text = data.HintCosts[0].ToString();
+                    }
+
+                    switch (hintObject["hintsType"].ToString())
+                    {
+                        case "Shananas":
+                            {
+                                SetMode(Mode.OpenKHShanHints);
+                                ShanHints(hintObject);
+                            }
+                            break;
+                        case "JSmartee":
+                            {
+                                SetMode(Mode.OpenKHJsmarteeHints);
+                                JsmarteeHints(hintObject);
+                            }
+                            break;
+                        case "Points":
+                            {
+                                SetMode(Mode.PointsHints);
+                                PointsHints(hintObject);
+                            }
+                            break;
+                        case "Path":
+                            {
+                                SetMode(Mode.PathHints);
+                                PathHints(hintObject);
+                            }
+                            break;
+                        case "Spoiler":
+                            {
+                                SetMode(Mode.SpoilerHints);
+                                SpoilerHints(hintObject);
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+
+                    data.hintsLoaded = true;
+
+                    reader.Close();
+                }
+            }
+
+            data.seedLoaded = true;
         }
 
         //hint helpers
@@ -2906,7 +3556,34 @@ namespace KhTracker
             int modsUsed = 0;
             Key _key;
 
-            Console.WriteLine(lines[1]);
+            try
+            {
+                string temp = lines[0];
+            }
+            catch
+            {
+                Console.WriteLine("No hotkeys detected, loading defaults");
+                mod1 = "Control";
+                key = "F12";
+
+                Console.WriteLine("idk = " + mod1 + " " + key);
+                if (key == "1" || key == "2" || key == "3" || key == "4" || key == "5"
+                     || key == "6" || key == "7" || key == "8" || key == "9" || key == "0")
+                {
+                    Enum.TryParse(ConvertKeyNumber(key, true), out _key);
+                    data.startAutoTracker1 = new GlobalHotkey(_mod1, _key, StartHotkey);
+                    HotkeysManager.AddHotkey(data.startAutoTracker1);
+
+                    Enum.TryParse(ConvertKeyNumber(key, false), out _key);
+                    data.startAutoTracker2 = new GlobalHotkey(_mod1, _key, StartHotkey);
+                    HotkeysManager.AddHotkey(data.startAutoTracker2);
+                    return;
+                }
+                Enum.TryParse(ConvertKey(key), out _key);
+                data.startAutoTracker1 = new GlobalHotkey(_mod1, _key, StartHotkey);
+                HotkeysManager.AddHotkey(data.startAutoTracker1);
+                return;
+            }
 
             //break out early if empty file
             if (lines.Length == 0)
@@ -3151,6 +3828,62 @@ namespace KhTracker
                     else
                         return "NumPad0";
             }
+        }
+
+        //Auto Load Hints
+        public void AutoLoadHints()
+        {
+            //if a seed was manually loaded, AutoLoad does not overwrite the seed
+            if (data.hintsLoaded || data.seedLoaded)
+            {
+                Console.WriteLine("Hints/seed already loaded, not continuing with AutoLoadHints");
+                return;
+            }
+
+            //if (AutoLoadHintsOption.IsChecked == true)
+            //    Console.WriteLine("AutoLoadHints enabled");
+            //else
+            //{
+            //    Console.WriteLine("AutoLoadHints disabled");
+            //    return;
+            //}
+
+            //Similar code in Toggle.cs
+            //If the user *somehow* deletes/edits the path to something incorrect after starting/selecting AutoLoad Hints
+            //This code will still check the path to make sure the tracker won't crash
+            string[] OpenKHPath = System.IO.File.ReadAllLines("./KhTrackerSettings/OpenKHPath.txt");
+            try
+            {
+                string temp = OpenKHPath[0];
+            }
+            catch
+            {
+                MessageBox.Show("OpenKH path does not exist. Please add/edit your path in the\n\"KhTrackerSettings/OpenKHPath.txt\" file next to the tracker.\nIf this issue persists, please ask for help\nin the KH2 Rando Discord server!\n\nWill auto-track now with no seed loaded.");
+                Console.WriteLine("No OpenKH path found, aborting");
+                return;
+            }
+
+            if (!Directory.Exists(OpenKHPath[0]))
+            {
+                MessageBox.Show("OpenKH path does not exist. Please add/edit your path in the\n\"KhTrackerSettings/OpenKHPath.txt\" file next to the tracker.\nIf this issue persists, please ask for help\nin the KH2 Rando Discord server!\n\nWill auto-track now with no seed loaded.");
+                return;
+            }
+            else
+                Console.WriteLine("OpenKH path found");
+
+            //get path for the mods folder where the seed is extracted to
+            string modsPath = OpenKHPath[0] + "\\mods\\kh2";
+            //get path(s) for the hint files
+            string[] hintFiles = System.IO.Directory.GetFiles(modsPath, "*.Hints", SearchOption.AllDirectories);
+
+            //foreach (string hintFile in hintFiles)
+            //    Console.WriteLine(hintFile);
+
+            //if exactly 1 hint file is found, we're good to load it
+            if (hintFiles.Length == 1)
+                OpenKHSeedExtracted(System.IO.Directory.GetParent(hintFiles[0]).ToString());
+            else
+                MessageBox.Show("Multiple hint files detected. Aborting Auto-Loading Hints.\nManually load your seed and/or re-check your Mod Manager.");
         }
     }
 }

--- a/KhTracker/Core/Options.cs
+++ b/KhTracker/Core/Options.cs
@@ -3900,7 +3900,8 @@ namespace KhTracker
             //if exactly 1 hint file is found, we're good to load it
             if (hintFiles.Length == 1)
                 OpenKHSeedExtracted(System.IO.Directory.GetParent(hintFiles[0]).ToString());
-            else
+            //if more than 1 hint file is found, don't load anything
+            else if (hintFiles.Length > 1)
                 MessageBox.Show("Multiple hint files detected. Aborting Auto-Loading Hints.\nManually load your seed and/or re-check your Mod Manager.");
         }
     }

--- a/KhTracker/Core/Toggles.cs
+++ b/KhTracker/Core/Toggles.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Windows.Data;
 using System.IO;
+using System.Text;
 
 namespace KhTracker
 {
@@ -1451,6 +1452,74 @@ namespace KhTracker
             Disconnect.IsChecked = toggle;
 
             //logic
+        }
+
+
+        //AutoLoadHints
+        private void AutoLoadHintsToggle(object sender, RoutedEventArgs e)
+        {
+            AutoLoadHintsToggle(AutoLoadHintsOption.IsChecked);
+        }
+        private void AutoLoadHintsToggle(bool toggle)
+        {
+            Properties.Settings.Default.AutoLoadHints = toggle;
+            AutoLoadHintsOption.IsChecked = toggle;
+
+            //create settings folder if it somehow doesn't exist
+            if (!Directory.Exists("./KhTrackerSettings"))
+            {
+                Directory.CreateDirectory("./KhTrackerSettings");
+            }
+            //create a txt file for the openkh location
+            if (!File.Exists("./KhTrackerSettings/OpenKHPath.txt"))
+            {
+                //Console.WriteLine("File not found, making");
+                using (FileStream fs = File.Create("./KhTrackerSettings/OpenKHPath.txt"))
+                {
+                    // Add some text to file    
+                    Byte[] title = new UTF8Encoding(true).GetBytes("C:\\Replace this path with the location of your\\openkh mod manager");
+                    fs.Write(title, 0, title.Length);
+                }
+            }
+
+            //check for a pre-defined mod manager path
+            //if it is invalid, bring up dialogue box to select a path
+
+            //this is ran whenever the tracker is open(ed) and sees the toggle is set
+            if (toggle)
+            {
+                string[] OpenKHPath = System.IO.File.ReadAllLines("./KhTrackerSettings/OpenKHPath.txt");
+                
+                //Check if the txt is empty or not (crashes when file is empty if user somehow manually deletes path)
+                try
+                {
+                    string temp = OpenKHPath[0];
+                }
+                //Ask to reset path if it's empty
+                catch
+                {
+                    if (MessageBox.Show("OpenKH path not set. Click OK to select your current\nOpenKH Mod Manager application (OpenKh.Tools.ModsManager.exe).\nA shortcut to your Mod Manager can also be selected.") == MessageBoxResult.OK)
+                    {
+                        //handled in MainWindow.xaml.cs
+                        SetOpenKHPath();
+                    }
+                    return;
+                }
+
+                //Console.WriteLine(System.IO.Directory.GetParent(OpenKHPath[0]).ToString());
+
+                if (Directory.Exists(OpenKHPath[0]))
+                {
+                    Console.WriteLine("OpenKH path found");
+                    return;
+                }
+                
+                if (MessageBox.Show("OpenKH path not set. Click OK to select your current\nOpenKH Mod Manager application (OpenKh.Tools.ModsManager.exe).\nA shortcut to your Mod Manager can also be selected.") == MessageBoxResult.OK)
+                {
+                    //handled in MainWindow.xaml.cs
+                    SetOpenKHPath();
+                }
+            }
         }
     }
 }

--- a/KhTracker/MainWindow.xaml
+++ b/KhTracker/MainWindow.xaml
@@ -12,7 +12,7 @@
         LocationChanged="Window_LocationChanged"
         SizeChanged="Window_SizeChanged"
         AllowDrop="True" Drop="DropFile"
-        Title="KH2 Tracker 2.34" Height="880" Width="570" Background="#303030"
+        Title="KH2 Tracker 2.34.2" Height="880" Width="570" Background="#303030"
         MinHeight="440" MinWidth="300">
 
     <Window.Resources>

--- a/KhTracker/MainWindow.xaml
+++ b/KhTracker/MainWindow.xaml
@@ -12,7 +12,7 @@
         LocationChanged="Window_LocationChanged"
         SizeChanged="Window_SizeChanged"
         AllowDrop="True" Drop="DropFile"
-        Title="KH2 Tracker 2.34.2" Height="880" Width="570" Background="#303030"
+        Title="KH2 Tracker 2.34" Height="880" Width="570" Background="#303030"
         MinHeight="440" MinWidth="300">
 
     <Window.Resources>

--- a/KhTracker/MainWindow.xaml
+++ b/KhTracker/MainWindow.xaml
@@ -33,6 +33,9 @@
                     <MenuItem Header="Load JSmartee Hints (*.hints)" 	Click="LoadHints"/>
                     <MenuItem Header="Load Shan Hints (*.pnach)" 		Click="ParseSeed"/>
                     <MenuItem Header="Load KH2Randomizer Seed (*.zip)" 	Click="OpenKHSeed"/>
+                    <Separator/>
+                    <MenuItem Header="Auto-Load Hints (openkh *.hints)" Click="AutoLoadHintsToggle" x:Name="AutoLoadHintsOption" IsCheckable="True" IsChecked="False"/>
+                    <MenuItem Header="Set OpenKH Path (OpenKh.Tools.ModsManager.exe)" Click="SetOpenKHPath"/>
                 </MenuItem>
                 <Separator/>
                 <MenuItem Header="Start Auto-Tracking" Click="InitTracker" x:Name="TrackToggle"/>

--- a/KhTracker/MainWindow.xaml.cs
+++ b/KhTracker/MainWindow.xaml.cs
@@ -633,7 +633,10 @@ namespace KhTracker
                     else
                     {
                         SetHintText(temp.Item1, temp.Item2, temp.Item3, temp.Item4, temp.Item5, temp.Item6);
-                        HighlightProgHintedWorlds(new List<string> { Codes.GetWorldName(temp.Item1) });
+                        if (data.mode == Mode.PathHints || data.mode == Mode.OpenKHJsmarteeHints)
+                            HighlightProgHintedWorlds(new List<string> { data.reportInformation[num - 1].Item2 });
+                        else
+                            HighlightProgHintedWorlds(new List<string> { Codes.GetWorldName(temp.Item1) });
                     }
 
                 }

--- a/KhTracker/MainWindow.xaml.cs
+++ b/KhTracker/MainWindow.xaml.cs
@@ -17,6 +17,7 @@ using System.ComponentModel;
 using System.Windows.Forms;
 using Button = System.Windows.Controls.Button;
 using KhTracker.Hotkeys;
+using System.Text;
 
 namespace KhTracker
 {
@@ -271,6 +272,10 @@ namespace KhTracker
             //message box
             Disconnect.IsChecked = Properties.Settings.Default.Disconnect;
             DisconnectToggle(Disconnect.IsChecked);
+
+            //autoloadhints
+            AutoLoadHintsOption.IsChecked = Properties.Settings.Default.AutoLoadHints;
+            AutoLoadHintsToggle(AutoLoadHintsOption.IsChecked);
 
             #endregion
 
@@ -578,6 +583,47 @@ namespace KhTracker
         {
             Width = 570;
             Height = 880;
+        }
+
+        //openkh path set
+        private void SetOpenKHPath(object sender, RoutedEventArgs e)
+        {
+            SetOpenKHPath();
+        }
+        public void SetOpenKHPath()
+        {
+            //create settings folder if it somehow doesn't exist
+            if (!Directory.Exists("./KhTrackerSettings"))
+            {
+                Directory.CreateDirectory("./KhTrackerSettings");
+            }
+            //create an txt file for the openkh location
+            if (!File.Exists("./KhTrackerSettings/OpenKHPath.txt"))
+            {
+                //Console.WriteLine("File not found, making");
+                using (FileStream fs = File.Create("./KhTrackerSettings/OpenKHPath.txt"))
+                {
+                    // Add some text to file    
+                    Byte[] title = new UTF8Encoding(true).GetBytes("C:\\Replace this path with the location of your\\openkh mod manager");
+                    fs.Write(title, 0, title.Length);
+                }
+            }
+
+            System.Windows.Forms.OpenFileDialog openFileDialog = new System.Windows.Forms.OpenFileDialog
+            {
+                DefaultExt = ".exe",
+                Filter = "exe files (*.exe)|*.exe"
+            };
+            System.Windows.Forms.DialogResult result = openFileDialog.ShowDialog();
+            if (result == System.Windows.Forms.DialogResult.OK)
+            {
+                using (FileStream fs = File.Create("./KhTrackerSettings/OpenKHPath.txt"))
+                {
+                    // Add some text to file    
+                    Byte[] title = new UTF8Encoding(true).GetBytes(System.IO.Directory.GetParent(openFileDialog.FileName).ToString());
+                    fs.Write(title, 0, title.Length);
+                }
+            }
         }
 
         /// 

--- a/KhTracker/MainWindow.xaml.cs
+++ b/KhTracker/MainWindow.xaml.cs
@@ -624,6 +624,9 @@ namespace KhTracker
                     fs.Write(title, 0, title.Length);
                 }
             }
+            else
+                System.Windows.Forms.MessageBox.Show("No path set. To set a path, go to\nOptions > Load Hints > Set OpenKH Path.");
+
         }
 
         /// 

--- a/KhTracker/MainWindow.xaml.cs
+++ b/KhTracker/MainWindow.xaml.cs
@@ -49,6 +49,7 @@ namespace KhTracker
             //hotkey stuff
             HotkeysManager.SetupSystemHook();
             LoadHotkeyBind();
+            ProgScrollHotkey();
 
             //start auto-connect if enabled
             AutoConnectOption.IsChecked = Properties.Settings.Default.AutoConnect;
@@ -527,6 +528,21 @@ namespace KhTracker
             if (data.WorldsData.ContainsKey(button.Name) && data.WorldsData[button.Name].value != null)
             {
                 ManualWorldValue(data.WorldsData[button.Name].value, e.Delta);
+            }
+        }
+
+        private void GoAScrollUp()
+        {
+            if (data.WorldsData.ContainsKey("GoA") && data.WorldsData["GoA"].value != null)
+            {
+                ManualWorldValue(data.WorldsData["GoA"].value, 1);
+            }
+        }
+        private void GoAScrollDown()
+        {
+            if (data.WorldsData.ContainsKey("GoA") && data.WorldsData["GoA"].value != null)
+            {
+                ManualWorldValue(data.WorldsData["GoA"].value, -1);
             }
         }
 

--- a/KhTracker/Properties/Settings.Designer.cs
+++ b/KhTracker/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace KhTracker.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.7.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -860,6 +860,18 @@ namespace KhTracker.Properties {
             }
             set {
                 this["AutoSaveProgress2"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool AutoLoadHints {
+            get {
+                return ((bool)(this["AutoLoadHints"]));
+            }
+            set {
+                this["AutoLoadHints"] = value;
             }
         }
     }

--- a/KhTracker/Properties/Settings.settings
+++ b/KhTracker/Properties/Settings.settings
@@ -212,5 +212,8 @@
     <Setting Name="AutoSaveProgress2" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="AutoLoadHints" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/KhTracker/WorldGrid.xaml.cs
+++ b/KhTracker/WorldGrid.xaml.cs
@@ -1482,7 +1482,7 @@ namespace KhTracker
                 //Console.WriteLine("~~~~~ MARKING WORLD AS COMPLETE");
                 data.WorldsData[worldName].complete = true;
                 //when a world is found as complete, give the stored bonuses
-                if (data.UsingProgressionHints)
+                if (data.UsingProgressionHints && data.hintsLoaded)
                 {
                     if (data.calulating)
                         data.ProgressionPoints += data.StoredWorldCompleteBonus[worldName];

--- a/KhTracker/WorldGrid.xaml.cs
+++ b/KhTracker/WorldGrid.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -517,6 +518,30 @@ namespace KhTracker
                             break;
                     }
                     return false;
+                }
+            }
+
+            //prog shan specific
+            if (item.Name.StartsWith("Report") && data.mode == Mode.OpenKHShanHints && data.UsingProgressionHints)
+            {
+                int index = int.Parse(item.Name.Remove(0, 6)) - 1;
+
+                if (!data.reportLocationsUsed[index])
+                {
+                    window.AddProgressionPoints(data.ReportBonus);
+                    data.reportLocationsUsed[index] = true;
+                }
+                else
+                {
+                    //check if the report was already obtained before giving points
+                    if (!data.reportLocationsUsed[index])
+                    {
+                        window.AddProgressionPoints(data.ReportBonus);
+                        data.reportLocationsUsed[index] = true;
+                    }
+                    // show hint text on report hover
+                    item.MouseEnter -= item.Report_Hover;
+                    item.MouseEnter += item.Report_Hover;
                 }
             }
 


### PR DESCRIPTION
Adds Option to Auto-Load the seed settings of an OpenKH seed in a user-specified OpenKH Mod Manager.
Enabled by going to clicking Options -> Load Hints -> Auto-Load Hints then following the prompts to input the Mod Manager exe location. Includes all error catching/edge-case logic.